### PR TITLE
Refactor page mapping benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ This benchmark also measures `seL4_Yield`
 
 This is a hot cache benchmark of the signal path in the kernel, measured from user level.
 
+## page_mapping
+
+This is a benchmark measuring mapping, unmapping, protecting and unprotecting a series of pages.
+
 ## smp
 
 This is an intra-core ipc round-trip benchmark to check overhead of the kernel synchronization on ipc throughput.

--- a/apps/page_mapping/Kconfig
+++ b/apps/page_mapping/Kconfig
@@ -13,8 +13,6 @@
 config APP_PAGEMAPPINGBENCH
     bool "Page mapping benchmarks"
     depends on APP_SEL4BENCH
-    depends on !PLAT_HIKEY
-    depends on !PLAT_TX1
     default y
     depends on LIB_SEL4 && HAVE_LIBC && LIB_SEL4_ALLOCMAN && LIB_UTILS && LIB_SEL4_UTILS && \
     LIB_SEL4_BENCH && LIB_ELF && LIB_SEL4_SIMPLE && LIB_CPIO && LIB_SEL4_VKA && LIB_SEL4_VSPACE && \

--- a/apps/page_mapping/src/main.c
+++ b/apps/page_mapping/src/main.c
@@ -16,223 +16,115 @@
 #include <benchmark.h>
 #include <page_mapping.h>
 
-#define START_ADDR 0x60000000
-#define NUM_ARGS 3
+#include <sel4utils/mapping.h>
 
-#if defined(CONFIG_ARCH_X86_64)
-#define DEFAULT_DEPTH 64
-#else
-#define DEFAULT_DEPTH 32
-#endif /* defined(CONFIG_ARCH_X86_64) */
-
-#define PAGE_PER_TABLE BIT(seL4_PageTableBits - seL4_WordSizeBits)
-#define untyped_retype_root(a,b,c,e)\
-		seL4_Untyped_Retype(a,b,c,SEL4UTILS_CNODE_SLOT,\
-						SEL4UTILS_CNODE_SLOT,DEFAULT_DEPTH,e,1)
-#define NUM_PAGE_TABLE(npage) DIV_ROUND_UP((npage), PAGE_PER_TABLE)
-
-typedef struct helper_thread {
-    sel4utils_process_t process;
-    seL4_CPtr untyped;
-    seL4_CPtr result_ep;
-    int npage;
-    char *argv[NUM_ARGS];
-    char argv_strings[NUM_ARGS][WORD_STRING_SIZE];
-} helper_thread_t;
-
-static void inline
-prepare_page_table(seL4_Word addr, int npage, seL4_CPtr untyped,
-                   seL4_CPtr *free_slot)
+static inline int
+alloc_pages(seL4_CPtr pages[], vka_t *vka, int npage, void* start_addr)
 {
-    long err UNUSED;
-    for (int i = 0; i < NUM_PAGE_TABLE(npage); i++) {
-        seL4_CPtr pt = *free_slot;
-        err = untyped_retype_root(untyped, seL4_ARCH_PageTableObject,
-                                  seL4_PageTableBits, pt);
-        assert(err == 0);
-        (*free_slot)++;
+    int err = 0;
+    void *addr = start_addr;
 
-        err = seL4_ARCH_PageTable_Map(pt, SEL4UTILS_PD_SLOT, addr,
-                                      seL4_ARCH_Default_VMAttributes);
+    for (int i = 0; i < npage; i++, addr += PAGE_SIZE_4K) {
+        int nobj;
+        vka_object_t tmp_obj[3]; // Max num of extra PT objects
+        vka_object_t frame_obj;
 
-#if defined(CONFIG_ARCH_X86_64)
+        err = vka_alloc_frame(vka, PAGE_BITS_4K, &frame_obj);
         if (err) {
-            seL4_CPtr pd = *free_slot;
-            err = untyped_retype_root(untyped, seL4_X86_PageDirectoryObject,
-                                      seL4_PageDirBits, pd);
-            assert(err == 0);
-            (*free_slot)++;
-            err = seL4_X86_PageDirectory_Map(pd, SEL4UTILS_PD_SLOT, addr,
-                                             seL4_ARCH_Default_VMAttributes);
-
-            if (err) {
-                seL4_CPtr pdpt = *free_slot;
-                err = untyped_retype_root(untyped, seL4_X86_PDPTObject,
-                                          seL4_PDPTBits, pdpt);
-                assert(err == 0);
-                (*free_slot)++;
-                err = seL4_X86_PDPT_Map(pdpt, SEL4UTILS_PD_SLOT, addr,
-                                        seL4_ARCH_Default_VMAttributes);
-                err = seL4_X86_PageDirectory_Map(pd, SEL4UTILS_PD_SLOT, addr,
-                                                 seL4_ARCH_Default_VMAttributes);
-            }
-
-            err = seL4_ARCH_PageTable_Map(pt, SEL4UTILS_PD_SLOT, addr,
-                                          seL4_ARCH_Default_VMAttributes);
+            ZF_LOGE_IFERR(err, "Failed to retype frame\n");
+            return err;
         }
 
-#endif /* CONFIG_ARCH_X86_64 */
-        assert(err == 0);
-        addr += PAGE_SIZE_4K * PAGE_PER_TABLE;
+        pages[i] = frame_obj.cptr;
+
+        /* Use sel4utils_map_page to map pages and allocate underlying 
+         * page table structure */
+        err = sel4utils_map_page(vka, SEL4UTILS_PD_SLOT, pages[i],
+                                 addr, seL4_AllRights, true, tmp_obj, &nobj);
+        if (err) {
+            ZF_LOGE_IFERR(err, "Failed map pages\n");
+            return err;
+        }
+
+        /* Unmap pages because benchmark assums pages unmapped to start with */
+        err = seL4_ARCH_Page_Unmap(pages[i]);
+        if (err) {
+            ZF_LOGE_IFERR(err, "Failed unmap pages\n");
+            return err;
+        }
     }
+
+    return err;
 }
 
-static void inline
-prepare_pages(int npage, seL4_CPtr untyped,
-              seL4_CPtr *free_slot)
-{
-    long err UNUSED;
-    for (int i = 0; i < npage; i++) {
-        err = untyped_retype_root(untyped, seL4_ARCH_4KPage, seL4_PageBits,
-                                  *free_slot);
-        assert(err == 0);
-
-        (*free_slot)++;
-    }
-}
-
-static void inline
-map_pages(seL4_CPtr addr, seL4_CPtr page_cap, int npage)
-{
-    long err UNUSED;
-    for (int i = 0; i < npage; i++) {
-        err = seL4_ARCH_Page_Map(page_cap, SEL4UTILS_PD_SLOT, addr,
-                                 seL4_AllRights, seL4_ARCH_Default_VMAttributes);
-        assert(err == 0);
-        addr += PAGE_SIZE_4K;
-        page_cap++;
-    }
-}
-
-#define PROT_UNPROT_NPAGE(func, right)\
-	static void inline func(seL4_CPtr page_cap, int npage){\
-		long err UNUSED;\
-		for(int i = 0; i < npage; i++){\
-			err = seL4_ARCH_Page_Remap(page_cap, SEL4UTILS_PD_SLOT, right,\
-							seL4_ARCH_Default_VMAttributes);\
-			assert(err == 0);\
-			page_cap++;\
-		}\
-	}
-PROT_UNPROT_NPAGE(prot_pages, seL4_CanRead)
-PROT_UNPROT_NPAGE(unprot_pages, seL4_AllRights)
-
-/* Benchmark Child Process */
 static void
-bench_proc(int argc UNUSED, char *argv[])
+run_bench(seL4_CPtr pages[], int npage, ccnt_t result[NPHASE], void* start_addr)
 {
-    seL4_CPtr result_ep = (seL4_CPtr)atoi(argv[0]);
-    seL4_CPtr untyped = (seL4_CPtr)atoi(argv[1]);
-    int npage = atoi(argv[2]);
-    seL4_CPtr free_slot = untyped + 1;
-    seL4_Word addr = START_ADDR;
     ccnt_t start, end;
-
-    sel4bench_init();
-
-    seL4_CPtr pt_ptr_start = free_slot;
-    /* Install page tables to avoid mapping to fail */
-    COMPILER_MEMORY_FENCE();
-    SEL4BENCH_READ_CCNT(start);
-
-    prepare_page_table(addr, npage, untyped, &free_slot);
-
-    SEL4BENCH_READ_CCNT(end);
-    COMPILER_MEMORY_FENCE();
-    send_result(result_ep, end - start);
-
-    seL4_CPtr page_ptr_start = free_slot;
-    /* allocate pages */
-    COMPILER_MEMORY_FENCE();
-    SEL4BENCH_READ_CCNT(start);
-
-    prepare_pages(npage, untyped, &free_slot);
-
-    SEL4BENCH_READ_CCNT(end);
-    COMPILER_MEMORY_FENCE();
-    send_result(result_ep, end - start);
+    int err UNUSED;
+    void *addr = (void*)start_addr;
 
     /* Do the real mapping */
     COMPILER_MEMORY_FENCE();
     SEL4BENCH_READ_CCNT(start);
 
-    map_pages(addr, page_ptr_start, npage);
+    for (int i = 0; i < npage; i++, addr += BIT(seL4_PageBits)) {
+        err = seL4_ARCH_Page_Map(pages[i], SEL4UTILS_PD_SLOT, (seL4_Word)addr,
+                                 seL4_AllRights, seL4_ARCH_Default_VMAttributes);
+        assert(err == 0);
+    }
 
     SEL4BENCH_READ_CCNT(end);
     COMPILER_MEMORY_FENCE();
-    send_result(result_ep, end - start);
+    result[MAP] = end - start;
 
-    /* Protect mapped page as seL4_CanRead */
+    /* Protect mapped page as seL4_NoRights */
     COMPILER_MEMORY_FENCE();
     SEL4BENCH_READ_CCNT(start);
 
-    prot_pages(page_ptr_start, npage);
+    for (int i = 0; i < npage; i++) {
+        err = seL4_ARCH_Page_Remap(pages[i], SEL4UTILS_PD_SLOT, seL4_NoRights,
+                                   seL4_ARCH_Default_VMAttributes);
+        assert(err == 0);
+    }
 
     SEL4BENCH_READ_CCNT(end);
     COMPILER_MEMORY_FENCE();
-    send_result(result_ep, end - start);
+    result[PROTECT] = end - start;
+
 
     /* Unprotect it back */
     COMPILER_MEMORY_FENCE();
     SEL4BENCH_READ_CCNT(start);
 
-    unprot_pages(page_ptr_start, npage);
+    for (int i = 0; i < npage; i++) {
+        err = seL4_ARCH_Page_Remap(pages[i], SEL4UTILS_PD_SLOT, seL4_AllRights,
+                                   seL4_ARCH_Default_VMAttributes);
+        assert(err == 0);
+    }
 
     SEL4BENCH_READ_CCNT(end);
     COMPILER_MEMORY_FENCE();
-    send_result(result_ep, end - start);
+    result[UNPROTECT] = end - start;
 
-    /* cleaning */
-    long err;
+    /* Unmap pages*/
+    COMPILER_MEMORY_FENCE();
+    SEL4BENCH_READ_CCNT(start);
+
     for (int i = 0; i < npage; i++) {
-        err = seL4_ARCH_Page_Unmap(page_ptr_start + i);
-        ZF_LOGF_IFERR(err, "ummap page failed\n");
+        err = seL4_ARCH_Page_Unmap(pages[i]);
+        assert(err == 0);
     }
 
-    for (int i = 0; i < NUM_PAGE_TABLE(npage); i++) {
-        err = seL4_ARCH_PageTable_Unmap(pt_ptr_start + i);
-        ZF_LOGF_IFERR(err, "ummap page table failed\n");
-
-    }
-
-    sel4bench_destroy();
-}
-
-static void
-run_bench_child_proc(env_t *env,
-                     cspacepath_t *result_ep_path,
-                     ccnt_t result[NPHASE],
-                     helper_thread_t *proc
-                    )
-{
-
-    if (sel4utils_spawn_process(&proc->process, &env->delegate_vka, &env->vspace,
-                                NUM_ARGS, proc->argv, 1) != 0) {
-        ZF_LOGF("Failed to spawn client\n");
-    }
-
-    /* Get result from benchmarking process */
-    for (int i = 0; i < NPHASE; i++) {
-        result[i] = get_result(result_ep_path->capPtr);
-    }
+    SEL4BENCH_READ_CCNT(end);
+    COMPILER_MEMORY_FENCE();
+    result[UNMAP] = end - start;
 }
 
 static void
 measure_overhead(page_mapping_results_t *results)
 {
     ccnt_t start, end;
-
-    sel4bench_init();
 
     /* Measure cycle counter overhead  */
     for (int i = 0; i < RUNS; i++) {
@@ -243,8 +135,46 @@ measure_overhead(page_mapping_results_t *results)
         COMPILER_MEMORY_FENCE();
         results->overhead_benchmarks[i] = end - start;
     }
+}
 
-    sel4bench_destroy();
+static int
+start_bench(env_t *env, page_mapping_results_t *results, int max_page, 
+            void* start_addr)
+{
+    seL4_CPtr pages[max_page];
+    int err;
+
+    err = alloc_pages(pages, &env->delegate_vka, max_page, start_addr);
+    if (err) {
+        return err;
+    }
+
+    for (int i = 0; i < RUNS; i++) {
+        for (int j = 0; j < TESTS; j++) {
+            /* run test */
+            ccnt_t ret_time[NPHASE] = {0};
+            run_bench(pages, page_mapping_benchmark_params[j].npage, ret_time,
+                      start_addr);
+            /* record result */
+            for (int k = 0; k < NPHASE; k++) {
+                results->benchmarks_result[j][k][i] = ret_time[k];
+            }
+        }
+    }
+
+    return err;
+}
+
+static inline int
+get_max_page()
+{
+    int max_page = 0;
+
+    for (int i = 0; i < TESTS; i++) {
+        max_page = MAX(max_page, page_mapping_benchmark_params[i].npage);
+    }
+
+    return max_page;
 }
 
 int
@@ -252,13 +182,10 @@ main(int argc, char *argv[])
 {
     env_t *env;
     page_mapping_results_t *results;
-    vka_object_t result_ep, untyped_obj;
-    cspacepath_t result_ep_path, untyped_path;
-    helper_thread_t proc;
+    void* start_addr;
+    int max_page;
 
     static size_t object_freq[seL4_ObjectTypeCount] = {
-        [seL4_TCBObject] = 1,
-        [seL4_EndpointObject] = 1,
 #ifdef CONFIG_KERNEL_RT
         [seL4_SchedContextObject] = 1,
         [seL4_ReplyObject] = 1
@@ -267,59 +194,29 @@ main(int argc, char *argv[])
 
     env = benchmark_get_env(argc, argv, sizeof(page_mapping_results_t),
                             object_freq);
+
+    /* Find maxium pages needed by benchmarks */
+    max_page = get_max_page();
+
+    /* Reserve a range of vspace enough to accomodate max_page 4K pages*/
+    vspace_reserve_range(&env->vspace, max_page * PAGE_SIZE_4K, seL4_AllRights,
+                 true, &start_addr);
+    assert(IS_ALIGNED((seL4_Word)start_addr, seL4_PageBits));
+
     results = (page_mapping_results_t *)env->results;
 
-    /* allocate result end point */
-    if (vka_alloc_endpoint(&env->slab_vka, &result_ep) != 0) {
-        ZF_LOGF("Failed to allocate endpoint");
-    }
-    vka_cspace_make_path(&env->slab_vka, result_ep.cptr, &result_ep_path);
-
-    /* allocate untyped cap for pages */
-    if ((vka_alloc_untyped(&env->delegate_vka, env->args->untyped_size_bits - 2,
-                           &untyped_obj)) != 0) {
-        ZF_LOGF("alloc untyped fail\n");
-    };
-    vka_cspace_make_path(&env->delegate_vka, untyped_obj.cptr, &untyped_path);
-
-    /* Create a new process to run test
-     * shallow clone only copy .text segment
-     * */
-    benchmark_shallow_clone_process(env, &proc.process, seL4_MaxPrio,
-                                    bench_proc, "Proc");
-
-    proc.result_ep = sel4utils_copy_path_to_process(&proc.process,
-                                                    result_ep_path);
+    sel4bench_init();
 
     measure_overhead(results);
-    for (int i = 0; i < RUNS; i++) {
-        for (int j = 0; j < TESTS; j++) {
-            proc.untyped = sel4utils_copy_path_to_process(&proc.process,
-                                                          untyped_path);
-            proc.npage = page_mapping_benchmark_params[j].npage;
 
-            sel4utils_create_word_args(proc.argv_strings, proc.argv, NUM_ARGS,
-                                       proc.result_ep, proc.untyped, proc.npage);
-
-            /* run test */
-            ccnt_t ret_time[NPHASE] = {0};
-            run_bench_child_proc(env, &result_ep_path, ret_time, &proc);
-            /* record result */
-            for (int k = 0; k < NPHASE; k++) {
-                results->benchmarks_result[j][k][i] = ret_time[k];
-            }
-            vka_cnode_revoke(&untyped_path);
-
-            /* Mannually set next free slot to make sure untyped cap is set
-             * at the same slot every time*/
-            proc.process.cspace_next_free--;
-
-            /* suspend proc to be resued */
-            seL4_TCB_Suspend(proc.process.thread.tcb.cptr);
-        }
+    if (start_bench(env, results, max_page, start_addr)) {
+        benchmark_finished(EXIT_FAILURE);
     }
-    vka_free_object(&env->delegate_vka, &untyped_obj);
+    else {
+        benchmark_finished(EXIT_SUCCESS);
+    }
 
-    benchmark_finished(EXIT_SUCCESS);
+    sel4bench_destroy();
+
     return 0;
 }

--- a/libsel4benchsupport/include/page_mapping.h
+++ b/libsel4benchsupport/include/page_mapping.h
@@ -18,7 +18,6 @@
 
 #define RUNS 16
 #define TESTS ARRAY_SIZE(page_mapping_benchmark_params)
-#define NPHASE ARRAY_SIZE(phase_name)
 
 typedef struct benchmark_params {
     /* name of the function we are benchmarking */
@@ -73,24 +72,27 @@ benchmark_params_t page_mapping_benchmark_params[] = {
                 .name   = "map 1024",
                 .npage  = 1024,
         },
-        {
-                .name   = "map 2048",
-                .npage  = 2048,
-        },
 };
 
-char *phase_name[] = {
-	"Prepare Page Tables",
-	"Allocate Pages",
-	"Mapping",
-	"Protect Pages as Read Only",
-	"Unprotect Pages"
+enum {
+    MAP,
+    PROTECT,
+    UNPROTECT,
+    UNMAP,
+    NPHASE
+};
+
+char *phase_name[NPHASE] = {
+    [MAP] = "Map Pages",
+    [PROTECT] = "Protect Pages",
+    [UNPROTECT] = "Unprotect Pages",
+    [UNMAP] = "Unmap Pages",
 };
 
 typedef struct page_mapping_results {
     /* Raw results from benchmarking. These get checked for sanity */
     ccnt_t overhead_benchmarks[RUNS];
-	ccnt_t benchmarks_result[TESTS][NPHASE][RUNS];
+    ccnt_t benchmarks_result[TESTS][NPHASE][RUNS];
 } page_mapping_results_t;
 
 #endif /* __BENCH_MAPPING_H_H */


### PR DESCRIPTION
1. Remove benchmark for allocating and mapping page table objects,
which did not make much sense.
2. Add benchmark for unmapping pages.
3. Run benchmark functions in main thread instead of dedicated proc.
4. To increase compatibility, use sel4vka to allocate objects and
sel4utils to map pages.
5. Use sel4vspace to reserve range of vspace for benchmark pages, so
that no address needs to be set manually.
6. Benchmark results are reorganized.
7. Fix support for TX1 and hikey, and hopefully other aarch64
platforms.