### PR TITLE
riscv: add hardware benchmark support

### DIFF
--- a/libsel4benchsupport/arch_include/riscv/arch/hardware.h
+++ b/libsel4benchsupport/arch_include/riscv/arch/hardware.h
@@ -11,4 +11,12 @@
  */
 #pragma once
 
+#define DO_NULLSYSCALL_OP(swi, syscall) do {\
+    register seL4_Word scno asm("a7") = syscall; \
+    asm volatile (NOPS swi NOPS :: "r"(scno)); \
+} while (0);
+
 #define DO_NULLSYSCALL(swi) DO_NULLSYSCALL_OP(swi, seL4_SysBenchmarkNullSyscall)
+
+#define DO_REAL_NULLSYSCALL()     DO_NULLSYSCALL("ecall")
+#define DO_NOP_NULLSYSCALL()      DO_NULLSYSCALL("nop")


### PR DESCRIPTION
This adds support for the hardware benchmark application on RISC-V.