### PR TITLE
github: add sel4bench deployment action

### DIFF
--- a/.github/workflows/sel4bench.yml
+++ b/.github/workflows/sel4bench.yml
@@ -1,0 +1,121 @@
+# Copyright 2021, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+# Deploy default.xml to sel4bench-manifest after successful runs.
+
+name: seL4Bench
+
+on:
+  push:
+    branches: [master]
+    paths-ignore:
+      - '**.md'
+
+  # allow manual trigger
+  workflow_dispatch:
+
+  # allow explict trigger from other repos when dependencies have changed
+  repository_dispatch:
+    types: [deps-update]
+
+jobs:
+  code:
+    name: Freeze Code
+    runs-on: ubuntu-latest
+    outputs:
+      xml: ${{ steps.repo.outputs.xml }}
+    steps:
+    - id: repo
+      uses: seL4/ci-actions/repo-checkout@master
+      with:
+        manifest_repo: sel4bench-manifest
+        manifest: master.xml
+
+  build:
+    name: Build
+    needs: code
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        march: [armv7a, armv8a, nehalem, rv64imac]
+    steps:
+    - name: Build
+      uses: seL4/ci-actions/sel4bench@master
+      with:
+        xml: ${{ needs.code.outputs.xml }}
+        march: ${{ matrix.march }}
+    - name: Upload images
+      uses: actions/upload-artifact@v2
+      with:
+        name: images-${{ matrix.march }}
+        path: '*-images.tar.gz'
+
+  hw-run:
+    name: HW Run
+    if: ${{ github.repository_owner == 'seL4' }}
+    runs-on: ubuntu-latest
+    needs: [build]
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - sabre
+          - imx8mm_evk
+          - odroid_c2
+          - odroid_xu4
+          - am335x_boneblack
+          - tx2
+          - hifive
+        include:
+          - platform: pc99
+            req: skylake
+          - platform: pc99
+            req: haswell3
+    # do not run concurrently with other workflows, but do run concurrently in the build matrix
+    concurrency: sel4bench-hw-${{ strategy.job-index }}
+    steps:
+      - name: Get machine queue
+        uses: actions/checkout@v2
+        with:
+          repository: seL4/machine_queue
+          path: machine_queue
+          token: ${{ secrets.PRIV_REPO_TOKEN }}
+      - name: Get march
+        id: plat
+        uses: seL4/ci-actions/march-of-platform@master
+        with:
+          platform: ${{ matrix.platform }}
+      - name: Download image
+        uses: actions/download-artifact@v2
+        with:
+          name: images-${{ steps.plat.outputs.march }}
+      - name: Run
+        uses: seL4/ci-actions/sel4bench-hw@master
+        with:
+          platform: ${{ matrix.platform }}
+          req: ${{ matrix.req }}
+          index: $${{ strategy.job-index }}
+        env:
+          HW_SSH: ${{ secrets.HW_SSH }}
+      - name: Upload results
+        uses: actions/upload-artifact@v2
+        with:
+          # funky expression below is to work around lack of ternary operator
+          name: sel4bench-results-${{ matrix.platform }}${{ matrix.req != '' && format('-{0}', matrix.req) || '' }}
+          path: '*.json'
+
+  deploy:
+    name: Deploy manifest
+    if: ${{ github.repository_owner == 'seL4' }}
+    runs-on: ubuntu-latest
+    needs: [code, hw-run]
+    steps:
+    - name: Deploy
+      uses: seL4/ci-actions/manifest-deploy@master
+      with:
+        xml: ${{ needs.code.outputs.xml }}
+        manifest_repo: sel4bench-manifest
+      env:
+        GH_SSH: ${{ secrets.CI_SSH }}


### PR DESCRIPTION
This will build `sel4bench` images, run them on hardware, and deploy a new `default.xml` manifest to the `sel4bench-manifest` repo when successful.

See sel4bench action at seL4/ci-actions#162