### PR TITLE
add cmake script to choose benchmark apps

### DIFF
--- a/benchmark_list.cmake
+++ b/benchmark_list.cmake
@@ -4,50 +4,40 @@
 # SPDX-License-Identifier: BSD-2-Clause
 #
 
-
 # Set the list of benchmark applications to be included into the image
 # Uncomment command set() when needed
-
 
 # Application to benchmark seL4 IPC
 # default AppIpcBench is ON
 # set(AppIpcBench OFF)
 
-
 # Application to benchmark seL4 IRQs from inside the kernel
 # default AppIrqBench is OFF, see apps/irq/CMakeLists.txt for current state of the benchmark
 # set(AppIrqBench ON)
-
 
 # Application to benchmark seL4 IRQs without modification to the kernel
 # default AppIrqUserBench is ON
 # set(AppIrqUserBench OFF)
 
-
 # Application to benchmark seL4 scheduler without modification to the kernel
 # default AppSchedulerBench is ON
 # set(AppSchedulerBench OFF)
-
 
 # Application to benchmark seL4 signals without modification to the kernel
 # default AppSignalBench is ON
 # set(AppSignalBench OFF)
 
-
 # Enable SMP benchmarks
 # default AppSmpBench is OFF
 # set(AppSmpBench ON)
-
 
 # Application to benchmark seL4 VCPU performance
 # default AppVcpuBench is OFF
 # set(AppVcpuBench ON)
 
-
 # Application to benchmark seL4 mapping a series of pages
 # default AppPageMappingBench is ON
 # set(AppPageMappingBench OFF)
-
 
 # Application to benchmark seL4 sync
 # default AppSyncBench is ON
@@ -56,7 +46,6 @@
 # Application to benchmark seL4 faults without modification to the kernel
 # default AppFaultBench is OFF
 # set(AppFaultBench ON)
-
 
 # Application to benchmark hardware-related operations
 # default AppHardwareBench is OFF

--- a/benchmark_list.cmake
+++ b/benchmark_list.cmake
@@ -1,0 +1,63 @@
+#
+# Copyright 2022, Nataliya Korovkina <malus.brandywine@gmail.com>
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+
+
+# Set the list of benchmark applications to be included into the image
+# Uncomment command set() when needed
+
+
+# Application to benchmark seL4 IPC
+# default AppIpcBench is ON
+# set(AppIpcBench OFF)
+
+
+# Application to benchmark seL4 IRQs from inside the kernel
+# default AppIrqBench is OFF, see apps/irq/CMakeLists.txt for current state of the benchmark
+# set(AppIrqBench ON)
+
+
+# Application to benchmark seL4 IRQs without modification to the kernel
+# default AppIrqUserBench is ON
+# set(AppIrqUserBench OFF)
+
+
+# Application to benchmark seL4 scheduler without modification to the kernel
+# default AppSchedulerBench is ON
+# set(AppSchedulerBench OFF)
+
+
+# Application to benchmark seL4 signals without modification to the kernel
+# default AppSignalBench is ON
+# set(AppSignalBench OFF)
+
+
+# Enable SMP benchmarks
+# default AppSmpBench is OFF
+# set(AppSmpBench ON)
+
+
+# Application to benchmark seL4 VCPU performance
+# default AppVcpuBench is OFF
+# set(AppVcpuBench ON)
+
+
+# Application to benchmark seL4 mapping a series of pages
+# default AppPageMappingBench is ON
+# set(AppPageMappingBench OFF)
+
+
+# Application to benchmark seL4 sync
+# default AppSyncBench is ON
+# set(AppSyncBench OFF)
+
+# Application to benchmark seL4 faults without modification to the kernel
+# default AppFaultBench is OFF
+# set(AppFaultBench ON)
+
+
+# Application to benchmark hardware-related operations
+# default AppHardwareBench is OFF
+# set(AppHardwareBench ON)

--- a/settings.cmake
+++ b/settings.cmake
@@ -23,6 +23,9 @@ set(OPENSBI_PATH "${project_dir}/tools/opensbi" CACHE STRING "OpenSBI Folder loc
 set(SEL4_CONFIG_DEFAULT_ADVANCED ON)
 include(application_settings)
 
+# setup the configuration of the benchmark suite
+include(${CMAKE_CURRENT_LIST_DIR}/benchmark_list.cmake)
+
 include(${CMAKE_CURRENT_LIST_DIR}/easy-settings.cmake)
 
 if(VCPU)


### PR DESCRIPTION
While developing/debugging application, its very useful to run only
the application that a developer works on. It reduces the amount of
output and helps seeing debug custom messages.

Signed-off-by: Nataliya Korovkina <malus.brandywine@gmail.com>