### PR TITLE
add CI build with clang

### DIFF
--- a/.github/workflows/sel4bench-pr.yml
+++ b/.github/workflows/sel4bench-pr.yml
@@ -44,16 +44,18 @@ jobs:
       fail-fast: false
       matrix:
         march: [armv7a, armv8a, nehalem, rv64imac]
+        compiler: [gcc, clang]
     steps:
     - name: Build
       uses: seL4/ci-actions/sel4bench@master
       with:
         xml: ${{ needs.code.outputs.xml }}
         march: ${{ matrix.march }}
+        compiler: ${{ matrix.compiler }}
     - name: Upload images
       uses: actions/upload-artifact@v4
       with:
-        name: images-${{ matrix.march }}
+        name: images-${{ matrix.march }}-${{matrix.compiler}}
         path: '*-images.tar.gz'
 
   hw-run:
@@ -100,7 +102,7 @@ jobs:
       - name: Download image
         uses: actions/download-artifact@v4
         with:
-          name: images-${{ steps.plat.outputs.march }}
+          name: images-${{ steps.plat.outputs.march }}-${{matrix.compiler}}
       - name: Run
         uses: seL4/ci-actions/sel4bench-hw@master
         with:
@@ -113,5 +115,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           # funky expression below is to work around lack of ternary operator
-          name: sel4bench-results-${{ matrix.platform }}${{ matrix.req != '' && format('-{0}', matrix.req) || '' }}
+          name: sel4bench-results-${{ matrix.platform }}${{ matrix.req != '' && format('-{0}', matrix.req) || '' }}-${{matrix.compiler}}
           path: '*.json'

--- a/.github/workflows/sel4bench-pr.yml
+++ b/.github/workflows/sel4bench-pr.yml
@@ -30,7 +30,7 @@ jobs:
       xml: ${{ steps.repo.outputs.xml }}
     steps:
     - id: repo
-      uses: seL4/ci-actions/repo-checkout@master
+      uses: axel-h/ci-actions/repo-checkout@patch-axel-16
       with:
         manifest_repo: sel4bench-manifest
         manifest: master.xml
@@ -46,7 +46,7 @@ jobs:
         march: [armv7a, armv8a, nehalem, rv64imac]
     steps:
     - name: Build
-      uses: seL4/ci-actions/sel4bench@master
+      uses: axel-h/ci-actions/sel4bench@patch-axel-16
       with:
         xml: ${{ needs.code.outputs.xml }}
         march: ${{ matrix.march }}
@@ -94,7 +94,7 @@ jobs:
           path: machine_queue
       - name: Get march
         id: plat
-        uses: seL4/ci-actions/march-of-platform@master
+        uses: axel-h/ci-actions/march-of-platform@patch-axel-16
         with:
           platform: ${{ matrix.platform }}
       - name: Download image
@@ -102,7 +102,7 @@ jobs:
         with:
           name: images-${{ steps.plat.outputs.march }}
       - name: Run
-        uses: seL4/ci-actions/sel4bench-hw@master
+        uses: axel-h/ci-actions/sel4bench-hw@patch-axel-16
         with:
           platform: ${{ matrix.platform }}
           req: ${{ matrix.req }}

--- a/.github/workflows/sel4bench.yml
+++ b/.github/workflows/sel4bench.yml
@@ -40,16 +40,18 @@ jobs:
       fail-fast: false
       matrix:
         march: [armv7a, armv8a, nehalem, rv64imac]
+        compiler: [gcc, clang]
     steps:
     - name: Build
       uses: seL4/ci-actions/sel4bench@master
       with:
         xml: ${{ needs.code.outputs.xml }}
         march: ${{ matrix.march }}
+        compiler: ${{ matrix.compiler }}
     - name: Upload images
       uses: actions/upload-artifact@v4
       with:
-        name: images-${{ matrix.march }}
+        name: images-${{ matrix.march }}-${{matrix.compiler}}
         path: '*-images.tar.gz'
 
   hw-run:
@@ -90,7 +92,7 @@ jobs:
       - name: Download image
         uses: actions/download-artifact@v4
         with:
-          name: images-${{ steps.plat.outputs.march }}
+          name: images-${{ steps.plat.outputs.march }}-${{matrix.compiler}}
       - name: Run
         uses: seL4/ci-actions/sel4bench-hw@master
         with:
@@ -103,7 +105,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           # funky expression below is to work around lack of ternary operator
-          name: sel4bench-results-${{ matrix.platform }}${{ matrix.req != '' && format('-{0}', matrix.req) || '' }}
+          name: sel4bench-results-${{ matrix.platform }}${{ matrix.req != '' && format('-{0}', matrix.req) || '' }}-${{matrix.compiler}}
           path: '*.json'
 
   deploy:
@@ -128,23 +130,23 @@ jobs:
     - name: Get results for web deployment (sabre)
       uses: actions/download-artifact@v4
       with:
-        name: sel4bench-results-sabre
+        name: sel4bench-results-sabre-gcc
     - name: Get results for web deployment (haswell)
       uses: actions/download-artifact@v4
       with:
-        name: sel4bench-results-pc99-haswell3
+        name: sel4bench-results-pc99-haswell3-gcc
     - name: Get results for web deployment (skylake)
       uses: actions/download-artifact@v4
       with:
-        name: sel4bench-results-pc99-skylake
+        name: sel4bench-results-pc99-skylake-gcc
     - name: Get results for web deployment (tx1)
       uses: actions/download-artifact@v4
       with:
-        name: sel4bench-results-tx1
+        name: sel4bench-results-tx1-gcc
     - name: Get results for web deployment (hifive)
       uses: actions/download-artifact@v4
       with:
-        name: sel4bench-results-hifive
+        name: sel4bench-results-hifive-gcc
     - name: Generate web page
       uses: seL4/ci-actions/sel4bench-web@master
       with:

--- a/.github/workflows/sel4bench.yml
+++ b/.github/workflows/sel4bench.yml
@@ -27,7 +27,7 @@ jobs:
       xml: ${{ steps.repo.outputs.xml }}
     steps:
     - id: repo
-      uses: seL4/ci-actions/repo-checkout@master
+      uses: axel-h/ci-actions/repo-checkout@patch-axel-16
       with:
         manifest_repo: sel4bench-manifest
         manifest: master.xml
@@ -42,7 +42,7 @@ jobs:
         march: [armv7a, armv8a, nehalem, rv64imac]
     steps:
     - name: Build
-      uses: seL4/ci-actions/sel4bench@master
+      uses: axel-h/ci-actions/sel4bench@patch-axel-16
       with:
         xml: ${{ needs.code.outputs.xml }}
         march: ${{ matrix.march }}
@@ -84,7 +84,7 @@ jobs:
           path: machine_queue
       - name: Get march
         id: plat
-        uses: seL4/ci-actions/march-of-platform@master
+        uses: axel-h/ci-actions/march-of-platform@patch-axel-16
         with:
           platform: ${{ matrix.platform }}
       - name: Download image
@@ -92,7 +92,7 @@ jobs:
         with:
           name: images-${{ steps.plat.outputs.march }}
       - name: Run
-        uses: seL4/ci-actions/sel4bench-hw@master
+        uses: axel-h/ci-actions/sel4bench-hw@patch-axel-16
         with:
           platform: ${{ matrix.platform }}
           req: ${{ matrix.req }}
@@ -114,7 +114,7 @@ jobs:
     steps:
     - name: Deploy manifest
       id: deploy
-      uses: seL4/ci-actions/manifest-deploy@master
+      uses: axel-h/ci-actions/manifest-deploy@patch-axel-16
       with:
         xml: ${{ needs.code.outputs.xml }}
         manifest_repo: sel4bench-manifest
@@ -146,7 +146,7 @@ jobs:
       with:
         name: sel4bench-results-hifive
     - name: Generate web page
-      uses: seL4/ci-actions/sel4bench-web@master
+      uses: axel-h/ci-actions/sel4bench-web@patch-axel-16
       with:
         manifest_sha: ${{ steps.deploy.outputs.manifest_sha }}
     - name: Deploy web page

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,8 @@
 # SPDX-License-Identifier: BSD-2-Clause
 #
 
+# dummy change
+
 cmake_minimum_required(VERSION 3.7.2)
 
 include(settings.cmake)

--- a/settings.cmake
+++ b/settings.cmake
@@ -64,7 +64,14 @@ if(NOT Sel4benchAllowSettingsOverride)
     # This option is controlled by ApplyCommonReleaseVerificationSettings
     mark_as_advanced(CMAKE_BUILD_TYPE)
     if(RELEASE)
-        if(NOT KernelArchRiscV)
+        # Known issues with KernelFWholeProgram ('-fwhole-program'):
+        # - the RISC-V kernel build with gcc currently fails due to a missing
+        #   compiler runtime helper function.
+        # - this option is not supposed by 'clang' at all. Note that we can't
+        #   check CMAKE_C_COMPILER_ID here, because it is empty, as this file
+        #   might get processed before CMake does any compiler evaluation. Thus,
+        #   the only option is checking if TRIPLE is set or not.
+        if((NOT KernelArchRiscV) AND (TRIPLE STREQUAL ""))
             set(KernelFWholeProgram ON CACHE BOOL "" FORCE)
         endif()
     endif()


### PR DESCRIPTION
This addresses parts of https://github.com/seL4/sel4bench/issues/21 and adds a build with clang. The resulting archive gets the suffix `-clang`. For `gcc` builds no suffix is used to avoid breaking any existing workflows.