### PR TITLE
bench/signal: early processing methodology

### DIFF
--- a/apps/sel4bench/src/math.c
+++ b/apps/sel4bench/src/math.c
@@ -155,42 +155,28 @@ result_t calculate_results(const size_t n, ccnt_t data[n])
     return result;
 }
 
-
-static double results_variance_early_proc(const size_t n, const ccnt_t sum, const ccnt_t sum2, const ccnt_t mean)
+static double results_variance_early_proc(const size_t num, const ccnt_t sum,
+                                          const ccnt_t sum2, const ccnt_t mean)
 {
     long double variance = 0;
     long double dm = mean, dsum = sum, dsum2 = sum2;
 
-    /* sigma = ( sum(x^2) - 2m*sum(x) + n*m^2 ) / n */
+    /* sigma = ( sum(x^2) - 2m*sum(x) + n*m^2 ) / num */
 
-    variance = (dsum2 - 2 * dm * dsum + n * dm * dm) / n;
+    variance = (dsum2 - 2 * dm * dsum + num * dm * dm) / num;
 
     return variance;
 }
 
-
-/*
- * received data:
- * data[0] - min
- * data[1] - max
- * data[2] - sum of samples
- * data[3] - sum of squared samples
- * array[num] -  raw data array, has to be fed to printing function
- */
-result_t calculate_results_early_proc(ccnt_t num, ccnt_t min, ccnt_t max, ccnt_t sum, ccnt_t sum2, ccnt_t array[num])
+result_t calculate_results_early_proc(ccnt_t num, ccnt_t sum, ccnt_t sum2, ccnt_t array[num])
 {
 
     result_t result;
-    result.min = min;
-    result.max = max;
-    assert(result.min <= result.max);
+
+    memset((void *)&result, 0, sizeof(result));
     result.mean = sum / num;
     result.variance = results_variance_early_proc(num, sum, sum2, result.mean);
-    result.stddev = sqrt(result.variance * ((double) num / (double)(num - 1.0f)));
-    result.median = 0;
-    result.first_quantile = 0;
-    result.third_quantile = 0;
-    result.mode = 0;
+    result.stddev = sqrt(result.variance * ((double) num / (double)(num - 1.0f)));;
     result.raw_data = array;
     result.samples = num;
 

--- a/apps/sel4bench/src/math.c
+++ b/apps/sel4bench/src/math.c
@@ -154,3 +154,46 @@ result_t calculate_results(const size_t n, ccnt_t data[n])
 
     return result;
 }
+
+
+static double results_variance_early_proc(const size_t n, const ccnt_t sum, const ccnt_t sum2, const ccnt_t mean)
+{
+    long double variance = 0;
+    long double dm = mean, dsum = sum, dsum2 = sum2;
+
+    /* sigma = ( sum(x^2) - 2m*sum(x) + n*m^2 ) / n */
+
+    variance = (dsum2 - 2 * dm * dsum + n * dm * dm) / n;
+
+    return variance;
+}
+
+
+/*
+ * received data:
+ * data[0] - min
+ * data[1] - max
+ * data[2] - sum of samples
+ * data[3] - sum of squared samples
+ * array[num] -  raw data array, has to be fed to printing function
+ */
+result_t calculate_results_early_proc(ccnt_t num, ccnt_t min, ccnt_t max, ccnt_t sum, ccnt_t sum2, ccnt_t array[num])
+{
+
+    result_t result;
+    result.min = min;
+    result.max = max;
+    assert(result.min <= result.max);
+    result.mean = sum / num;
+    result.variance = results_variance_early_proc(num, sum, sum2, result.mean);
+    result.stddev = sqrt(result.variance * ((double) num / (double)(num - 1.0f)));
+    result.median = 0;
+    result.first_quantile = 0;
+    result.third_quantile = 0;
+    result.mode = 0;
+    result.raw_data = array;
+    result.samples = num;
+
+    return result;
+
+}

--- a/apps/sel4bench/src/math.h
+++ b/apps/sel4bench/src/math.h
@@ -10,8 +10,23 @@
 
 result_t calculate_results(const size_t n, ccnt_t data[n]);
 
-result_t calculate_results_early_proc(ccnt_t num, ccnt_t min, ccnt_t max,
-                                      ccnt_t sum, ccnt_t sum2, ccnt_t array[num]);
+/*
+ * The function calculates parameters of array elements received from
+ * a benchmark which used early processing methodology
+ * @param num - number of samples
+ * @param sum - sum of samples
+ * @param sum2 - sum of squared samples
+ * @param array - array of raw data which are zeros for Early Processing methodology
+ * but the array is required for results output function
+ */
+result_t calculate_results_early_proc(ccnt_t num, ccnt_t sum, ccnt_t sum2,
+                                      ccnt_t array[num]);
 
-static double results_variance_early_proc(const size_t n, const ccnt_t sum,
+/* The function calculates variance using sum, sum of squared values and mean
+ * @param num - number of samples
+ * @param sum - sum of samples
+ * @param sum2 - sum of squared samples
+ * @param mean - mean of the samples
+*/
+static double results_variance_early_proc(const size_t num, const ccnt_t sum,
                                           const ccnt_t sum2, const ccnt_t mean);

--- a/apps/sel4bench/src/math.h
+++ b/apps/sel4bench/src/math.h
@@ -9,3 +9,9 @@
 #include "benchmark.h"
 
 result_t calculate_results(const size_t n, ccnt_t data[n]);
+
+result_t calculate_results_early_proc(ccnt_t num, ccnt_t min, ccnt_t max,
+                                      ccnt_t sum, ccnt_t sum2, ccnt_t array[num]);
+
+static double results_variance_early_proc(const size_t n, const ccnt_t sum,
+                                          const ccnt_t sum2, const ccnt_t mean);

--- a/apps/sel4bench/src/processing.c
+++ b/apps/sel4bench/src/processing.c
@@ -63,6 +63,12 @@ result_t process_result(size_t n, ccnt_t array[n], result_desc_t desc)
     return calculate_results(size, array);
 }
 
+/* For Early Processing configuration */
+result_t process_result_early_proc(ccnt_t num, ccnt_t min, ccnt_t max, ccnt_t sum, ccnt_t sum2, ccnt_t array[num])
+{
+    return calculate_results_early_proc(num, min, max, sum, sum2, array);
+}
+
 void process_results(size_t ncols, size_t nrows, ccnt_t array[ncols][nrows], result_desc_t desc,
                      result_t results[ncols])
 {

--- a/apps/sel4bench/src/processing.c
+++ b/apps/sel4bench/src/processing.c
@@ -63,10 +63,9 @@ result_t process_result(size_t n, ccnt_t array[n], result_desc_t desc)
     return calculate_results(size, array);
 }
 
-/* For Early Processing configuration */
-result_t process_result_early_proc(ccnt_t num, ccnt_t min, ccnt_t max, ccnt_t sum, ccnt_t sum2, ccnt_t array[num])
+result_t process_result_early_proc(ccnt_t num, ccnt_t sum, ccnt_t sum2, ccnt_t array[num])
 {
-    return calculate_results_early_proc(num, min, max, sum, sum2, array);
+    return calculate_results_early_proc(num, sum, sum2, array);
 }
 
 void process_results(size_t ncols, size_t nrows, ccnt_t array[ncols][nrows], result_desc_t desc,

--- a/apps/sel4bench/src/processing.h
+++ b/apps/sel4bench/src/processing.h
@@ -17,6 +17,10 @@
  */
 result_t process_result(size_t n, ccnt_t array[n], result_desc_t desc);
 
+/*  For Early Processing configuration  */
+result_t process_result_early_proc(ccnt_t num, ccnt_t min, ccnt_t max,
+                                   ccnt_t sum, ccnt_t sum2, ccnt_t array[num]);
+
 /**
  * @param ncols    size of the 1st dimension of array.
  * @param nrows    size of the 2nd dimension of the array.

--- a/apps/sel4bench/src/processing.h
+++ b/apps/sel4bench/src/processing.h
@@ -17,9 +17,15 @@
  */
 result_t process_result(size_t n, ccnt_t array[n], result_desc_t desc);
 
-/*  For Early Processing configuration  */
-result_t process_result_early_proc(ccnt_t num, ccnt_t min, ccnt_t max,
-                                   ccnt_t sum, ccnt_t sum2, ccnt_t array[num]);
+/* Compute the variance, standard deviation, mean for a set of values
+ * for benchmarks using Early Processing methodology
+ * @param num   number of values to process
+ * @param sum   sum of values
+ * @param sum2  sum of squared values
+ * @param array raw values to compute results for
+ */
+result_t process_result_early_proc(ccnt_t num, ccnt_t sum, ccnt_t sum2,
+                                   ccnt_t array[num]);
 
 /**
  * @param ncols    size of the 1st dimension of array.

--- a/apps/sel4bench/src/signal.c
+++ b/apps/sel4bench/src/signal.c
@@ -35,9 +35,17 @@ static json_t *signal_process(void *results)
     desc.stable = false;
     desc.overhead = result.min;
 
+#if defined CONFIG_APP_SIGNAL_EARLYPROC
+    result = process_result_early_proc(raw_results->lo_num, raw_results->lo_min,
+                                       raw_results->lo_max, raw_results->lo_sum, raw_results->lo_sum2,
+                                       raw_results->lo_prio_results);
+#else
     result = process_result(N_RUNS, raw_results->lo_prio_results, desc);
+#endif
+
     set.name = "Signal to high prio thread";
     json_array_append_new(array, result_set_to_json(set));
+
 
     result = process_result(N_RUNS, raw_results->hi_prio_results, desc);
     set.name = "Signal to low prio thread";

--- a/apps/sel4bench/src/signal.c
+++ b/apps/sel4bench/src/signal.c
@@ -36,8 +36,8 @@ static json_t *signal_process(void *results)
     desc.overhead = result.min;
 
 #if defined CONFIG_APP_SIGNAL_EARLYPROC
-    result = process_result_early_proc(raw_results->lo_num, raw_results->lo_min,
-                                       raw_results->lo_max, raw_results->lo_sum, raw_results->lo_sum2,
+    result = process_result_early_proc(raw_results->lo_num,
+                                       raw_results->lo_sum, raw_results->lo_sum2,
                                        raw_results->lo_prio_results);
 #else
     result = process_result(N_RUNS, raw_results->lo_prio_results, desc);

--- a/apps/sel4bench/src/signal.c
+++ b/apps/sel4bench/src/signal.c
@@ -35,17 +35,16 @@ static json_t *signal_process(void *results)
     desc.stable = false;
     desc.overhead = result.min;
 
-#if defined CONFIG_APP_SIGNAL_EARLYPROC
     result = process_result_early_proc(raw_results->lo_num,
                                        raw_results->lo_sum, raw_results->lo_sum2,
-                                       raw_results->lo_prio_results);
-#else
-    result = process_result(N_RUNS, raw_results->lo_prio_results, desc);
-#endif
+                                       raw_results->diag_results);
 
-    set.name = "Signal to high prio thread";
+    set.name = "Signal to high prio thread (early processing)";
     json_array_append_new(array, result_set_to_json(set));
 
+    result = process_result(N_RUNS, raw_results->lo_prio_results, desc);
+    set.name = "Signal to high prio thread";
+    json_array_append_new(array, result_set_to_json(set));
 
     result = process_result(N_RUNS, raw_results->hi_prio_results, desc);
     set.name = "Signal to low prio thread";

--- a/apps/signal/CMakeLists.txt
+++ b/apps/signal/CMakeLists.txt
@@ -18,6 +18,14 @@ config_option(
     DEPENDS
     "DefaultBenchDeps"
 )
+config_option(
+    AppSignalEarlyProcessing
+    APP_SIGNAL_EARLYPROC
+    "Apply early processing of the raw results for Signal benchmark"
+    DEFAULT
+    OFF
+)
+
 add_config_library(sel4benchsignal "${configure_string}")
 
 file(GLOB deps src/*.c)

--- a/apps/signal/CMakeLists.txt
+++ b/apps/signal/CMakeLists.txt
@@ -18,13 +18,6 @@ config_option(
     DEPENDS
     "DefaultBenchDeps"
 )
-config_option(
-    AppSignalEarlyProcessing
-    APP_SIGNAL_EARLYPROC
-    "Apply early processing of the raw results for Signal benchmark"
-    DEFAULT
-    OFF
-)
 
 add_config_library(sel4benchsignal "${configure_string}")
 

--- a/easy-settings.cmake
+++ b/easy-settings.cmake
@@ -60,3 +60,7 @@ set(MAPPING ON CACHE BOOL "Application to benchmark seL4 mapping a series of pag
 
 # default is ON
 set(SYNC ON CACHE BOOL "Application to benchmark seL4 sync")
+
+# Allow Early Processing methodology for
+#Signal/"Signal to High Prio Thread" benchmark
+#set(AppSignalEarlyProcessing ON)

--- a/libsel4benchsupport/include/benchmark.h
+++ b/libsel4benchsupport/include/benchmark.h
@@ -28,6 +28,25 @@
 
 #define MAX_TIMER_IRQS 4
 
+/* Data collection support macros, to be used in individual benchmark apps*/
+
+/* Declare and init internal parameters: "sample" and "is_counted" */
+#define DATACOLLECT_INIT()    ccnt_t sample = 0; seL4_Word is_counted;
+
+/* Find out if "i"-th sample will be recorded (if "i" less than "n",
+ * the sample will be ignored.
+ * Then calculate sample using start value "s", end value "e" and
+ * value of overhead "o".
+ * Then accumulate sum of samples "par_sum" and sum of squared samples
+ * "par_sum2".
+ */
+#define DATACOLLECT_GET_SUMS(i, n, s, e, o, par_sum, par_sum2) \
+{\
+is_counted = ( ~(i - n) ) >> (seL4_WordBits - 1);\
+sample = is_counted * (e - s - o);\
+par_sum += sample; par_sum2 += sample * sample;\
+}
+
 /* benchmarking environment set up by root task */
 typedef struct env {
     /* vka interface for allocating *fast* objects in the benchmark */

--- a/libsel4benchsupport/include/sel4benchsupport/signal.h
+++ b/libsel4benchsupport/include/sel4benchsupport/signal.h
@@ -13,7 +13,14 @@
 
 typedef struct signal_results {
     ccnt_t lo_prio_results[N_RUNS];
+    ccnt_t lo_min;
+    ccnt_t lo_max;
+    ccnt_t lo_sum;
+    ccnt_t lo_sum2;
+    ccnt_t lo_num; /* number of samples to process */
+
     ccnt_t hi_prio_results[N_RUNS];
     ccnt_t overhead[N_RUNS];
+    ccnt_t overhead_min;
     ccnt_t hi_prio_average[N_RUNS][NUM_AVERAGE_EVENTS];
 } signal_results_t;

--- a/libsel4benchsupport/include/sel4benchsupport/signal.h
+++ b/libsel4benchsupport/include/sel4benchsupport/signal.h
@@ -13,14 +13,12 @@
 
 typedef struct signal_results {
     ccnt_t lo_prio_results[N_RUNS];
-    ccnt_t lo_min;
-    ccnt_t lo_max;
-    ccnt_t lo_sum;
-    ccnt_t lo_sum2;
-    ccnt_t lo_num; /* number of samples to process */
-
     ccnt_t hi_prio_results[N_RUNS];
     ccnt_t overhead[N_RUNS];
-    ccnt_t overhead_min;
     ccnt_t hi_prio_average[N_RUNS][NUM_AVERAGE_EVENTS];
+    /* Parameters intrinsic to early processing */
+    ccnt_t lo_sum; /* sum of samples */
+    ccnt_t lo_sum2; /* sum of squared samples */
+    ccnt_t lo_num; /* number of samples to process */
+    ccnt_t overhead_min; /* min overhead found in "overhead" array */
 } signal_results_t;

--- a/libsel4benchsupport/include/sel4benchsupport/signal.h
+++ b/libsel4benchsupport/include/sel4benchsupport/signal.h
@@ -12,13 +12,17 @@
 #define N_RUNS (100 + N_IGNORED)
 
 typedef struct signal_results {
+    /* Data for late processing */
     ccnt_t lo_prio_results[N_RUNS];
     ccnt_t hi_prio_results[N_RUNS];
-    ccnt_t overhead[N_RUNS];
     ccnt_t hi_prio_average[N_RUNS][NUM_AVERAGE_EVENTS];
-    /* Parameters intrinsic to early processing */
+    ccnt_t overhead[N_RUNS]; /* "overhead" is used by early processing as well */
+    /* Data for early processing */
     ccnt_t lo_sum; /* sum of samples */
     ccnt_t lo_sum2; /* sum of squared samples */
     ccnt_t lo_num; /* number of samples to process */
     ccnt_t overhead_min; /* min overhead found in "overhead" array */
+    /* array required by report output function
+    Zeros, but can be used for diagnostic data */
+    ccnt_t diag_results[N_RUNS]; /* array required by report output function */
 } signal_results_t;


### PR DESCRIPTION
Implementation of "Early Processing" methodology for "Signal to High
Prio Thread" benchmark.

Benchmarks have to collect considerably large sequence of measurements
to process them in a later phase. Processing comprises calculation of
distribution parameters.

Initially introduced methodology sequentially saves the measurements in
an array. In some cases it may cause D-cache line evictions and
following D-cache line refills that occur inside the measurement period.

Early processing methodology accumulates four paramaters which necessary
to calculate mean, variance and standard deviation, during collection
phase, and drops individual measurements.

Signed-off-by: Nataliya Korovkina <malus.brandywine@gmail.com>