### PR TITLE
github: provide correct PR branch input

### DIFF
--- a/.github/workflows/sel4bench-pr.yml
+++ b/.github/workflows/sel4bench-pr.yml
@@ -28,6 +28,7 @@ jobs:
       with:
         manifest_repo: sel4bench-manifest
         manifest: master.xml
+        sha: ${{ github.event.pull_request.head.sha }}
 
   build:
     name: Build


### PR DESCRIPTION
Previously, PR checks would run on `master` instead of the PR itself.