### PR TITLE
Early Processing Methodology in More Benchmarks

### DIFF
--- a/apps/hardware/src/main.c
+++ b/apps/hardware/src/main.c
@@ -49,6 +49,25 @@ void measure_nullsyscall(ccnt_t *results)
 
 }
 
+void measure_nullsyscall_ep(hardware_results_t *results)
+{
+    ccnt_t start, end, sum = 0, sum2 = 0, overhead;
+
+    overhead = results->overhead_min;
+    DATACOLLECT_INIT();
+
+    for (seL4_Word i = 0; i < N_RUNS; i++) {
+        SEL4BENCH_READ_CCNT(start);
+        DO_REAL_NULLSYSCALL();
+        SEL4BENCH_READ_CCNT(end);
+        DATACOLLECT_GET_SUMS(i, N_IGNORED, start, end, overhead, sum, sum2);
+    }
+
+    results->nullSyscall_ep_sum = sum;
+    results->nullSyscall_ep_sum2 = sum2;
+    results->nullSyscall_ep_num = N_RUNS - N_IGNORED;
+}
+
 static env_t *env;
 
 void CONSTRUCTOR(MUSLCSYS_WITH_VSYSCALL_PRIORITY) init_env(void)
@@ -75,6 +94,7 @@ int main(int argc, char **argv)
     /* measure overhead */
     measure_nullsyscall_overhead(results->nullSyscall_overhead);
     measure_nullsyscall(results->nullSyscall_results);
+    measure_nullsyscall_ep(results);
 
     /* done -> results are stored in shared memory so we can now return */
     benchmark_finished(EXIT_SUCCESS);

--- a/apps/sel4bench/src/fault.c
+++ b/apps/sel4bench/src/fault.c
@@ -40,8 +40,18 @@ static json_t *fault_process(void *results)
     result = process_result(N_RUNS, raw_results->round_trip, desc);
     json_array_append_new(array, result_set_to_json(set));
 
+    set.name = "fault round trip (early processing)";
+    result = process_result_early_proc(raw_results->round_trip_ep_num, raw_results->round_trip_ep_sum,
+                                       raw_results->round_trip_ep_sum2, raw_results->round_trip_ep);
+    json_array_append_new(array, result_set_to_json(set));
+
     set.name = "faulter -> fault handler";
     result = process_result(N_RUNS, raw_results->fault, desc);
+    json_array_append_new(array, result_set_to_json(set));
+
+    set.name = "faulter -> fault handler (early processing)";
+    result = process_result_early_proc(raw_results->fault_ep_num, raw_results->fault_ep_sum,
+                                       raw_results->fault_ep_sum2, raw_results->fault_ep);
     json_array_append_new(array, result_set_to_json(set));
 
     /* calculate the overhead of reading the cycle count (fault handler -> faulter path
@@ -58,6 +68,12 @@ static json_t *fault_process(void *results)
     desc.stable = false;
     desc.overhead = result.min;
     result = process_result(N_RUNS, raw_results->fault_reply, desc);
+    json_array_append_new(array, result_set_to_json(set));
+
+    /* fault to fault handler does not */
+    set.name = "fault handler -> faulter (early processing)";
+    result = process_result_early_proc(raw_results->fault_reply_ep_num, raw_results->fault_reply_ep_sum,
+                                       raw_results->fault_reply_ep_sum2, raw_results->fault_reply_ep);
     json_array_append_new(array, result_set_to_json(set));
 
     return array;

--- a/apps/sel4bench/src/hardware.c
+++ b/apps/sel4bench/src/hardware.c
@@ -37,6 +37,11 @@ static json_t *hardware_process(void *results)
     json_t *array = json_array();
     json_array_append_new(array, result_set_to_json(set));
 
+    set.name = "Hardware null_syscall thread (early processing)";
+    result = process_result_early_proc(raw_results->nullSyscall_ep_num, raw_results->nullSyscall_ep_sum,
+                                       raw_results->nullSyscall_ep_sum2, raw_results->nullSyscall_ep);
+    json_array_append_new(array, result_set_to_json(set));
+
     set.name = "Nop syscall overhead";
     set.results = &nopnulsyscall_result;
     json_array_append_new(array, result_set_to_json(set));

--- a/apps/sel4bench/src/irq.c
+++ b/apps/sel4bench/src/irq.c
@@ -120,16 +120,27 @@ static json_t *irquser_process(void *r)
         .name = "IRQ user measurement overhead"
     };
 
-    result_t results[3];
+    result_t results[5];
 
     results[0] = process_result(N_RUNS, raw_results->overheads, desc);
 
     desc.overhead = results[0].min;
 
     results[1] = process_result(N_RUNS, raw_results->thread_results, desc);
-    results[2] = process_result(N_RUNS, raw_results->process_results, desc);
+    results[2] = process_result_early_proc(raw_results->thread_results_ep_num,
+                                           raw_results->thread_results_ep_sum,
+                                           raw_results->thread_results_ep_sum2,
+                                           raw_results->thread_results_ep);
+    results[3] = process_result(N_RUNS, raw_results->process_results, desc);
+    results[4] = process_result_early_proc(raw_results->process_results_ep_num,
+                                           raw_results->process_results_ep_sum,
+                                           raw_results->process_results_ep_sum2,
+                                           raw_results->process_results_ep);
 
-    char *types[] = {"Measurement overhead", "Without context switch", "With context switch"};
+    char *types[] = {"Measurement overhead", "Without context switch",
+                     "Without context switch (early processing)", "With context switch",
+                     "With context switch (early processing)"
+                    };
 
     column_t col = {
         .header = "Type",
@@ -139,7 +150,7 @@ static json_t *irquser_process(void *r)
 
     result_set_t set = {
         .name = "IRQ path cycle count (measured from user level)",
-        .n_results = 3,
+        .n_results = 5,
         .results = results,
         .n_extra_cols = 1,
         .extra_cols = &col

--- a/apps/sel4bench/src/math.c
+++ b/apps/sel4bench/src/math.c
@@ -155,42 +155,28 @@ result_t calculate_results(const size_t n, ccnt_t data[n])
     return result;
 }
 
-
-static double results_variance_early_proc(const size_t n, const ccnt_t sum, const ccnt_t sum2, const ccnt_t mean)
+static double results_variance_early_proc(const size_t num, const ccnt_t sum,
+                                          const ccnt_t sum2, const ccnt_t mean)
 {
     long double variance = 0;
     long double dm = mean, dsum = sum, dsum2 = sum2;
 
-    /* sigma = ( sum(x^2) - 2m*sum(x) + n*m^2 ) / n */
+    /* sigma = ( sum(x^2) - 2m*sum(x) + n*m^2 ) / num */
 
-    variance = (dsum2 - 2 * dm * dsum + n * dm * dm) / n;
+    variance = (dsum2 - 2 * dm * dsum + num * dm * dm) / num;
 
     return variance;
 }
 
-
-/*
- * received data:
- * data[0] - min
- * data[1] - max
- * data[2] - sum of samples
- * data[3] - sum of squared samples
- * array[num] -  raw data array, has to be fed to printing function
- */
-result_t calculate_results_early_proc(ccnt_t num, ccnt_t min, ccnt_t max, ccnt_t sum, ccnt_t sum2, ccnt_t array[num])
+result_t calculate_results_early_proc(ccnt_t num, ccnt_t sum, ccnt_t sum2, ccnt_t array[num])
 {
 
     result_t result;
-    result.min = min;
-    result.max = max;
-    assert(result.min <= result.max);
+
+    memset((void *)&result, 0, sizeof(result));
     result.mean = sum / num;
     result.variance = results_variance_early_proc(num, sum, sum2, result.mean);
-    result.stddev = sqrt(result.variance * ((double) num / (double)(num - 1.0f)));
-    result.median = 0;
-    result.first_quantile = 0;
-    result.third_quantile = 0;
-    result.mode = 0;
+    result.stddev = sqrt(result.variance * ((double) num / (double)(num - 1.0f)));;
     result.raw_data = array;
     result.samples = num;
 

--- a/apps/sel4bench/src/math.c
+++ b/apps/sel4bench/src/math.c
@@ -154,3 +154,46 @@ result_t calculate_results(const size_t n, ccnt_t data[n])
 
     return result;
 }
+
+
+static double results_variance_early_proc(const size_t n, const ccnt_t sum, const ccnt_t sum2, const ccnt_t mean)
+{
+    long double variance = 0;
+    long double dm = mean, dsum = sum, dsum2 = sum2;
+
+    /* sigma = ( sum(x^2) - 2m*sum(x) + n*m^2 ) / n */
+
+    variance = (dsum2 - 2 * dm * dsum + n * dm * dm) / n;
+
+    return variance;
+}
+
+
+/*
+ * received data:
+ * data[0] - min
+ * data[1] - max
+ * data[2] - sum of samples
+ * data[3] - sum of squared samples
+ * array[num] -  raw data array, has to be fed to printing function
+ */
+result_t calculate_results_early_proc(ccnt_t num, ccnt_t min, ccnt_t max, ccnt_t sum, ccnt_t sum2, ccnt_t array[num])
+{
+
+    result_t result;
+    result.min = min;
+    result.max = max;
+    assert(result.min <= result.max);
+    result.mean = sum / num;
+    result.variance = results_variance_early_proc(num, sum, sum2, result.mean);
+    result.stddev = sqrt(result.variance * ((double) num / (double)(num - 1.0f)));
+    result.median = 0;
+    result.first_quantile = 0;
+    result.third_quantile = 0;
+    result.mode = 0;
+    result.raw_data = array;
+    result.samples = num;
+
+    return result;
+
+}

--- a/apps/sel4bench/src/math.h
+++ b/apps/sel4bench/src/math.h
@@ -10,8 +10,23 @@
 
 result_t calculate_results(const size_t n, ccnt_t data[n]);
 
-result_t calculate_results_early_proc(ccnt_t num, ccnt_t min, ccnt_t max,
-                                      ccnt_t sum, ccnt_t sum2, ccnt_t array[num]);
+/*
+ * The function calculates parameters of array elements received from
+ * a benchmark which used early processing methodology
+ * @param num - number of samples
+ * @param sum - sum of samples
+ * @param sum2 - sum of squared samples
+ * @param array - array of raw data which are zeros for Early Processing methodology
+ * but the array is required for results output function
+ */
+result_t calculate_results_early_proc(ccnt_t num, ccnt_t sum, ccnt_t sum2,
+                                      ccnt_t array[num]);
 
-static double results_variance_early_proc(const size_t n, const ccnt_t sum,
+/* The function calculates variance using sum, sum of squared values and mean
+ * @param num - number of samples
+ * @param sum - sum of samples
+ * @param sum2 - sum of squared samples
+ * @param mean - mean of the samples
+*/
+static double results_variance_early_proc(const size_t num, const ccnt_t sum,
                                           const ccnt_t sum2, const ccnt_t mean);

--- a/apps/sel4bench/src/math.h
+++ b/apps/sel4bench/src/math.h
@@ -9,3 +9,9 @@
 #include "benchmark.h"
 
 result_t calculate_results(const size_t n, ccnt_t data[n]);
+
+result_t calculate_results_early_proc(ccnt_t num, ccnt_t min, ccnt_t max,
+                                      ccnt_t sum, ccnt_t sum2, ccnt_t array[num]);
+
+static double results_variance_early_proc(const size_t n, const ccnt_t sum,
+                                          const ccnt_t sum2, const ccnt_t mean);

--- a/apps/sel4bench/src/processing.c
+++ b/apps/sel4bench/src/processing.c
@@ -63,6 +63,12 @@ result_t process_result(size_t n, ccnt_t array[n], result_desc_t desc)
     return calculate_results(size, array);
 }
 
+/* For Early Processing configuration */
+result_t process_result_early_proc(ccnt_t num, ccnt_t min, ccnt_t max, ccnt_t sum, ccnt_t sum2, ccnt_t array[num])
+{
+    return calculate_results_early_proc(num, min, max, sum, sum2, array);
+}
+
 void process_results(size_t ncols, size_t nrows, ccnt_t array[ncols][nrows], result_desc_t desc,
                      result_t results[ncols])
 {

--- a/apps/sel4bench/src/processing.c
+++ b/apps/sel4bench/src/processing.c
@@ -63,10 +63,9 @@ result_t process_result(size_t n, ccnt_t array[n], result_desc_t desc)
     return calculate_results(size, array);
 }
 
-/* For Early Processing configuration */
-result_t process_result_early_proc(ccnt_t num, ccnt_t min, ccnt_t max, ccnt_t sum, ccnt_t sum2, ccnt_t array[num])
+result_t process_result_early_proc(ccnt_t num, ccnt_t sum, ccnt_t sum2, ccnt_t array[num])
 {
-    return calculate_results_early_proc(num, min, max, sum, sum2, array);
+    return calculate_results_early_proc(num, sum, sum2, array);
 }
 
 void process_results(size_t ncols, size_t nrows, ccnt_t array[ncols][nrows], result_desc_t desc,

--- a/apps/sel4bench/src/processing.h
+++ b/apps/sel4bench/src/processing.h
@@ -17,6 +17,10 @@
  */
 result_t process_result(size_t n, ccnt_t array[n], result_desc_t desc);
 
+/*  For Early Processing configuration  */
+result_t process_result_early_proc(ccnt_t num, ccnt_t min, ccnt_t max,
+                                   ccnt_t sum, ccnt_t sum2, ccnt_t array[num]);
+
 /**
  * @param ncols    size of the 1st dimension of array.
  * @param nrows    size of the 2nd dimension of the array.

--- a/apps/sel4bench/src/processing.h
+++ b/apps/sel4bench/src/processing.h
@@ -17,9 +17,15 @@
  */
 result_t process_result(size_t n, ccnt_t array[n], result_desc_t desc);
 
-/*  For Early Processing configuration  */
-result_t process_result_early_proc(ccnt_t num, ccnt_t min, ccnt_t max,
-                                   ccnt_t sum, ccnt_t sum2, ccnt_t array[num]);
+/* Compute the variance, standard deviation, mean for a set of values
+ * for benchmarks using Early Processing methodology
+ * @param num   number of values to process
+ * @param sum   sum of values
+ * @param sum2  sum of squared values
+ * @param array raw values to compute results for
+ */
+result_t process_result_early_proc(ccnt_t num, ccnt_t sum, ccnt_t sum2,
+                                   ccnt_t array[num]);
 
 /**
  * @param ncols    size of the 1st dimension of array.

--- a/apps/sel4bench/src/scheduler.c
+++ b/apps/sel4bench/src/scheduler.c
@@ -28,8 +28,18 @@ static void process_yield_results(scheduler_results_t *results, ccnt_t overhead,
     result = process_result(N_RUNS, results->thread_yield, desc);
     json_array_append_new(array, result_set_to_json(set));
 
+    set.name = "Thread yield (early processing)";
+    result = process_result_early_proc(results->thread_yield_ep_num, results->thread_yield_ep_sum,
+                                       results->thread_yield_ep_sum2, results->thread_yield_ep);
+    json_array_append_new(array, result_set_to_json(set));
+
     set.name = "Process yield";
     result = process_result(N_RUNS, results->process_yield, desc);
+    json_array_append_new(array, result_set_to_json(set));
+
+    set.name = "Process yield (early processing)";
+    result = process_result_early_proc(results->process_yield_ep_num, results->process_yield_ep_sum,
+                                       results->process_yield_ep_sum2, results->process_yield_ep);
     json_array_append_new(array, result_set_to_json(set));
 
     result_t average_results[NUM_AVERAGE_EVENTS];

--- a/apps/sel4bench/src/signal.c
+++ b/apps/sel4bench/src/signal.c
@@ -35,9 +35,17 @@ static json_t *signal_process(void *results)
     desc.stable = false;
     desc.overhead = result.min;
 
+#if defined CONFIG_APP_SIGNAL_EARLYPROC
+    result = process_result_early_proc(raw_results->lo_num, raw_results->lo_min,
+                                       raw_results->lo_max, raw_results->lo_sum, raw_results->lo_sum2,
+                                       raw_results->lo_prio_results);
+#else
     result = process_result(N_RUNS, raw_results->lo_prio_results, desc);
+#endif
+
     set.name = "Signal to high prio thread";
     json_array_append_new(array, result_set_to_json(set));
+
 
     result = process_result(N_RUNS, raw_results->hi_prio_results, desc);
     set.name = "Signal to low prio thread";

--- a/apps/sel4bench/src/signal.c
+++ b/apps/sel4bench/src/signal.c
@@ -36,8 +36,8 @@ static json_t *signal_process(void *results)
     desc.overhead = result.min;
 
 #if defined CONFIG_APP_SIGNAL_EARLYPROC
-    result = process_result_early_proc(raw_results->lo_num, raw_results->lo_min,
-                                       raw_results->lo_max, raw_results->lo_sum, raw_results->lo_sum2,
+    result = process_result_early_proc(raw_results->lo_num,
+                                       raw_results->lo_sum, raw_results->lo_sum2,
                                        raw_results->lo_prio_results);
 #else
     result = process_result(N_RUNS, raw_results->lo_prio_results, desc);

--- a/apps/sel4bench/src/signal.c
+++ b/apps/sel4bench/src/signal.c
@@ -35,17 +35,16 @@ static json_t *signal_process(void *results)
     desc.stable = false;
     desc.overhead = result.min;
 
-#if defined CONFIG_APP_SIGNAL_EARLYPROC
     result = process_result_early_proc(raw_results->lo_num,
                                        raw_results->lo_sum, raw_results->lo_sum2,
-                                       raw_results->lo_prio_results);
-#else
-    result = process_result(N_RUNS, raw_results->lo_prio_results, desc);
-#endif
+                                       raw_results->diag_results);
 
-    set.name = "Signal to high prio thread";
+    set.name = "Signal to high prio thread (early processing)";
     json_array_append_new(array, result_set_to_json(set));
 
+    result = process_result(N_RUNS, raw_results->lo_prio_results, desc);
+    set.name = "Signal to high prio thread";
+    json_array_append_new(array, result_set_to_json(set));
 
     result = process_result(N_RUNS, raw_results->hi_prio_results, desc);
     set.name = "Signal to low prio thread";

--- a/apps/sel4bench/src/sync.c
+++ b/apps/sel4bench/src/sync.c
@@ -74,6 +74,20 @@ static json_t *sync_process(void *results)
         json_array_append_new(array, result_set_to_json(set));
     }
 
+    result = process_result_early_proc(raw_results->producer_to_consumer_ep_num,
+                                       raw_results->producer_to_consumer_ep_sum,
+                                       raw_results->producer_to_consumer_ep_sum2,
+                                       raw_results->producer_to_consumer_ep);
+    set.name = "Producer to consumer (early processing)";
+    json_array_append_new(array, result_set_to_json(set));
+
+    result = process_result_early_proc(raw_results->consumer_to_producer_ep_num,
+                                       raw_results->consumer_to_producer_ep_sum,
+                                       raw_results->consumer_to_producer_ep_sum2,
+                                       raw_results->consumer_to_producer_ep);
+    set.name = "Consumer to producer (early processing)";
+    json_array_append_new(array, result_set_to_json(set));
+
     return array;
 }
 

--- a/apps/signal/CMakeLists.txt
+++ b/apps/signal/CMakeLists.txt
@@ -18,6 +18,14 @@ config_option(
     DEPENDS
     "DefaultBenchDeps"
 )
+config_option(
+    AppSignalEarlyProcessing
+    APP_SIGNAL_EARLYPROC
+    "Apply early processing of the raw results for Signal benchmark"
+    DEFAULT
+    OFF
+)
+
 add_config_library(sel4benchsignal "${configure_string}")
 
 file(GLOB deps src/*.c)

--- a/apps/signal/CMakeLists.txt
+++ b/apps/signal/CMakeLists.txt
@@ -18,13 +18,6 @@ config_option(
     DEPENDS
     "DefaultBenchDeps"
 )
-config_option(
-    AppSignalEarlyProcessing
-    APP_SIGNAL_EARLYPROC
-    "Apply early processing of the raw results for Signal benchmark"
-    DEFAULT
-    OFF
-)
 
 add_config_library(sel4benchsignal "${configure_string}")
 

--- a/apps/signal/src/main.c
+++ b/apps/signal/src/main.c
@@ -278,24 +278,6 @@ void measure_signal_overhead(seL4_CPtr ntfn, ccnt_t *results)
     }
 }
 
-/*
- * Execution flow for Early Processing: we have to calculate Min value
- * of measured overhead before running Signal benchmark.
- *
- * In "Late Processing" flow all the data are processed
- * after all the benchmarks has finished.
- */
-ccnt_t getMinOverhead(ccnt_t overhead[N_RUNS])
-{
-    ccnt_t min = -1;
-
-    for (int i = 0; i < N_RUNS; i++) {
-        min = (overhead[i] < min) ? overhead[i] : min;
-    }
-
-    return min;
-}
-
 static env_t *env;
 
 void CONSTRUCTOR(MUSLCSYS_WITH_VSYSCALL_PRIORITY) init_env(void)
@@ -346,7 +328,7 @@ int main(int argc, char **argv)
      * result_desc_t and CONFIG_ALLOW_UNSTABLE_OVERHEAD to deal with overhead.
      * NB! CONFIG_ALLOW_UNSTABLE_OVERHEAD is not avail. in signal app.
     */
-    results->overhead_min = getMinOverhead(results->overhead);
+    results->overhead_min = getMinOverhead(results->overhead, N_RUNS);
 
     benchmark(env, done_ep.cptr, ntfn.cptr, results);
 

--- a/apps/sync/src/main.c
+++ b/apps/sync/src/main.c
@@ -222,6 +222,86 @@ void benchmark_producer_consumer(env_t *env, seL4_CPtr ep, seL4_CPtr block_ep, s
     seL4_TCB_Suspend(consumer.tcb.cptr);
 }
 
+#define SYNC_PRODUCER_CONSUMER_FUNC_EP(name, condition, wait_func, work, direction) \
+    void \
+    name (int argc, char **argv) \
+    { \
+        seL4_CPtr done_ep = (seL4_CPtr) atol(argv[0]); \
+        seL4_CPtr block_ep = (seL4_CPtr) atol(argv[1]); \
+        sync_bin_sem_t *lock = (sync_bin_sem_t *) atol(argv[2]); \
+        sync_cv_t *wait_cv = (sync_cv_t *) atol(argv[3]); \
+        sync_cv_t *signal_cv = (sync_cv_t *) atol(argv[4]); \
+        int *fifo_head = (int *) atol(argv[5]); \
+        ccnt_t *start = (ccnt_t *) atol(argv[6]); \
+        ccnt_t *signal = (ccnt_t *) atol(argv[7]); \
+        sync_results_t *results = (sync_results_t *) atol(argv[8]); \
+        ccnt_t end, sum = 0, sum2 = 0; \
+        DATACOLLECT_INIT(); \
+        for (seL4_Word i = 0; i < N_RUNS; i++) { \
+            sync_bin_sem_wait(lock); \
+            while (condition) { \
+                wait_func(lock, wait_cv); \
+            } \
+            SEL4BENCH_READ_CCNT(end); \
+            DATACOLLECT_GET_SUMS(i, N_IGNORED, *start, end, 0, sum, sum2); \
+            work; \
+            SEL4BENCH_READ_CCNT(*signal); \
+            sync_cv_signal(signal_cv); \
+            sync_bin_sem_post(lock); \
+        } \
+        \
+        results->direction##_ep_sum = sum; \
+        results->direction##_ep_sum2 = sum2; \
+        results->direction##_ep_num = N_RUNS - N_IGNORED; \
+        \
+        seL4_Send(done_ep, seL4_MessageInfo_new(0, 0, 0, 0)); \
+        seL4_Wait(block_ep, NULL); \
+    }
+
+SYNC_PRODUCER_CONSUMER_FUNC_EP(consumer_func_ep, (*fifo_head == 0), sync_cv_wait, (*fifo_head)--, consumer_to_producer)
+
+SYNC_PRODUCER_CONSUMER_FUNC_EP(producer_func_ep, (*fifo_head == FIFO_SIZE), sync_cv_wait, (*fifo_head)++,
+                               producer_to_consumer)
+
+void benchmark_producer_consumer_ep(env_t *env, seL4_CPtr ep, seL4_CPtr block_ep, sync_bin_sem_t *lock,
+                                    sync_cv_t *producer_cv, sync_cv_t *consumer_cv, sync_results_t *results)
+{
+    sel4utils_thread_t producer, consumer;
+    char producer_args_strings[N_PRODUCER_CONSUMER_ARGS][WORD_STRING_SIZE];
+    char *producer_argv[N_PRODUCER_CONSUMER_ARGS];
+    char consumer_args_strings[N_PRODUCER_CONSUMER_ARGS][WORD_STRING_SIZE];
+    char *consumer_argv[N_PRODUCER_CONSUMER_ARGS];
+    int UNUSED error;
+
+    /* Create producer consumer threads */
+    benchmark_configure_thread(env, 0, seL4_MaxPrio, "producer", &producer);
+    benchmark_configure_thread(env, 0, seL4_MaxPrio, "consumer", &consumer);
+
+    int fifo_head = 0;
+    ccnt_t producer_signal, consumer_signal;
+
+    sel4utils_create_word_args(producer_args_strings, producer_argv, N_PRODUCER_CONSUMER_ARGS,
+                               ep, block_ep, lock, consumer_cv, producer_cv, &fifo_head,
+                               &producer_signal, &consumer_signal, results);
+
+    sel4utils_create_word_args(consumer_args_strings, consumer_argv, N_PRODUCER_CONSUMER_ARGS,
+                               ep, block_ep, lock, producer_cv, consumer_cv, &fifo_head,
+                               &consumer_signal, &producer_signal, results);
+
+    error = sel4utils_start_thread(&producer, (sel4utils_thread_entry_fn) producer_func_ep,
+                                   (void *) N_PRODUCER_CONSUMER_ARGS, (void *) producer_argv, 1);
+    assert(error == seL4_NoError);
+
+    error = sel4utils_start_thread(&consumer, (sel4utils_thread_entry_fn) consumer_func_ep,
+                                   (void *) N_PRODUCER_CONSUMER_ARGS, (void *) consumer_argv, 1);
+    assert(error == seL4_NoError);
+
+    benchmark_wait_children(ep, "Broadcast bench waiters", 2);
+
+    seL4_TCB_Suspend(producer.tcb.cptr);
+    seL4_TCB_Suspend(consumer.tcb.cptr);
+}
+
 static env_t *env;
 
 void CONSTRUCTOR(MUSLCSYS_WITH_VSYSCALL_PRIORITY) init_env(void)
@@ -286,6 +366,9 @@ int main(int argc, char **argv)
 
     benchmark_producer_consumer(env, done_ep.cptr, block_ep.cptr, &lock,
                                 &producer_cv, &consumer_cv, results);
+
+    benchmark_producer_consumer_ep(env, done_ep.cptr, block_ep.cptr, &lock,
+                                   &producer_cv, &consumer_cv, results);
 
     sync_cv_destroy(&env->slab_vka, &producer_cv);
     sync_cv_destroy(&env->slab_vka, &consumer_cv);

--- a/easy-settings.cmake
+++ b/easy-settings.cmake
@@ -60,3 +60,7 @@ set(MAPPING ON CACHE BOOL "Application to benchmark seL4 mapping a series of pag
 
 # default is ON
 set(SYNC ON CACHE BOOL "Application to benchmark seL4 sync")
+
+# Allow Early Processing methodology for
+#Signal/"Signal to High Prio Thread" benchmark
+#set(AppSignalEarlyProcessing ON)

--- a/libsel4benchsupport/include/benchmark.h
+++ b/libsel4benchsupport/include/benchmark.h
@@ -47,6 +47,18 @@ sample = is_counted * (e - s - o);\
 par_sum += sample; par_sum2 += sample * sample;\
 }
 
+/*
+ * Execution flow for Early Processing: we have to calculate min value
+ * of measured overheads before running benchmark.
+ *
+ * In "Late Processing" flow all the data is processed
+ * after all the benchmarks have finished.
+ *
+ * @param overhead array of overhead measurements
+ * @param overhead_size number of overhead measurements taken
+ */
+ccnt_t getMinOverhead(ccnt_t *overhead, seL4_Word overhead_size);
+
 /* benchmarking environment set up by root task */
 typedef struct env {
     /* vka interface for allocating *fast* objects in the benchmark */

--- a/libsel4benchsupport/include/benchmark.h
+++ b/libsel4benchsupport/include/benchmark.h
@@ -28,6 +28,25 @@
 
 #define MAX_TIMER_IRQS 4
 
+/* Data collection support macros, to be used in individual benchmark apps*/
+
+/* Declare and init internal parameters: "sample" and "is_counted" */
+#define DATACOLLECT_INIT()    ccnt_t sample = 0; seL4_Word is_counted;
+
+/* Find out if "i"-th sample will be recorded (if "i" less than "n",
+ * the sample will be ignored.
+ * Then calculate sample using start value "s", end value "e" and
+ * value of overhead "o".
+ * Then accumulate sum of samples "par_sum" and sum of squared samples
+ * "par_sum2".
+ */
+#define DATACOLLECT_GET_SUMS(i, n, s, e, o, par_sum, par_sum2) \
+{\
+is_counted = ( ~(i - n) ) >> (seL4_WordBits - 1);\
+sample = is_counted * (e - s - o);\
+par_sum += sample; par_sum2 += sample * sample;\
+}
+
 /* benchmarking environment set up by root task */
 typedef struct env {
     /* vka interface for allocating *fast* objects in the benchmark */

--- a/libsel4benchsupport/include/fault.h
+++ b/libsel4benchsupport/include/fault.h
@@ -21,4 +21,23 @@ typedef struct {
     ccnt_t round_trip[N_RUNS + 1];
     ccnt_t fault[N_RUNS + 1];
     ccnt_t fault_reply[N_RUNS + 1];
+
+    /* Data for early processing */
+    ccnt_t round_trip_ep_sum;
+    ccnt_t round_trip_ep_sum2;
+    ccnt_t round_trip_ep_num;
+    ccnt_t round_trip_ep_min_overhead;
+    ccnt_t round_trip_ep[N_RUNS];
+
+    ccnt_t fault_ep_sum;
+    ccnt_t fault_ep_sum2;
+    ccnt_t fault_ep_num;
+    ccnt_t fault_ep_min_overhead;
+    ccnt_t fault_ep[N_RUNS];
+
+    ccnt_t fault_reply_ep_sum;
+    ccnt_t fault_reply_ep_sum2;
+    ccnt_t fault_reply_ep_num;
+    ccnt_t fault_reply_ep_min_overhead;
+    ccnt_t fault_reply_ep[N_RUNS];
 } fault_results_t;

--- a/libsel4benchsupport/include/hardware.h
+++ b/libsel4benchsupport/include/hardware.h
@@ -13,4 +13,12 @@
 typedef struct hardware_results {
     ccnt_t nullSyscall_results[N_RUNS];
     ccnt_t nullSyscall_overhead[N_RUNS];
+
+    /* Data for early processing */
+    ccnt_t overhead_min;
+
+    ccnt_t nullSyscall_ep_sum;
+    ccnt_t nullSyscall_ep_sum2;
+    ccnt_t nullSyscall_ep_num;
+    ccnt_t nullSyscall_ep[N_RUNS];
 } hardware_results_t;

--- a/libsel4benchsupport/include/irq.h
+++ b/libsel4benchsupport/include/irq.h
@@ -23,4 +23,17 @@ typedef struct irquser_results_t {
     ccnt_t overheads[N_RUNS];
     ccnt_t thread_results[N_RUNS];
     ccnt_t process_results[N_RUNS];
+
+    /* Data for early processing */
+    ccnt_t overhead_min;
+
+    ccnt_t thread_results_ep_sum;
+    ccnt_t thread_results_ep_sum2;
+    ccnt_t thread_results_ep_num;
+    ccnt_t thread_results_ep[N_RUNS];
+
+    ccnt_t process_results_ep_sum;
+    ccnt_t process_results_ep_sum2;
+    ccnt_t process_results_ep_num;
+    ccnt_t process_results_ep[N_RUNS];
 } irquser_results_t;

--- a/libsel4benchsupport/include/scheduler.h
+++ b/libsel4benchsupport/include/scheduler.h
@@ -23,6 +23,18 @@ typedef struct scheduler_results_t {
     ccnt_t overhead_ccnt[N_RUNS];
     ccnt_t average_yield[N_RUNS][NUM_AVERAGE_EVENTS];
 
+    /* Data for early processing */
+    ccnt_t overhead_ccnt_min;
+
+    ccnt_t thread_yield_ep_sum;
+    ccnt_t thread_yield_ep_sum2;
+    ccnt_t thread_yield_ep_num;
+    ccnt_t thread_yield_ep[N_RUNS];
+
+    ccnt_t process_yield_ep_sum;
+    ccnt_t process_yield_ep_sum2;
+    ccnt_t process_yield_ep_num;
+    ccnt_t process_yield_ep[N_RUNS];
 } scheduler_results_t;
 
 static inline uint8_t gen_next_prio(int i)

--- a/libsel4benchsupport/include/sel4benchsupport/signal.h
+++ b/libsel4benchsupport/include/sel4benchsupport/signal.h
@@ -13,7 +13,14 @@
 
 typedef struct signal_results {
     ccnt_t lo_prio_results[N_RUNS];
+    ccnt_t lo_min;
+    ccnt_t lo_max;
+    ccnt_t lo_sum;
+    ccnt_t lo_sum2;
+    ccnt_t lo_num; /* number of samples to process */
+
     ccnt_t hi_prio_results[N_RUNS];
     ccnt_t overhead[N_RUNS];
+    ccnt_t overhead_min;
     ccnt_t hi_prio_average[N_RUNS][NUM_AVERAGE_EVENTS];
 } signal_results_t;

--- a/libsel4benchsupport/include/sel4benchsupport/signal.h
+++ b/libsel4benchsupport/include/sel4benchsupport/signal.h
@@ -13,14 +13,12 @@
 
 typedef struct signal_results {
     ccnt_t lo_prio_results[N_RUNS];
-    ccnt_t lo_min;
-    ccnt_t lo_max;
-    ccnt_t lo_sum;
-    ccnt_t lo_sum2;
-    ccnt_t lo_num; /* number of samples to process */
-
     ccnt_t hi_prio_results[N_RUNS];
     ccnt_t overhead[N_RUNS];
-    ccnt_t overhead_min;
     ccnt_t hi_prio_average[N_RUNS][NUM_AVERAGE_EVENTS];
+    /* Parameters intrinsic to early processing */
+    ccnt_t lo_sum; /* sum of samples */
+    ccnt_t lo_sum2; /* sum of squared samples */
+    ccnt_t lo_num; /* number of samples to process */
+    ccnt_t overhead_min; /* min overhead found in "overhead" array */
 } signal_results_t;

--- a/libsel4benchsupport/include/sel4benchsupport/signal.h
+++ b/libsel4benchsupport/include/sel4benchsupport/signal.h
@@ -12,13 +12,17 @@
 #define N_RUNS (100 + N_IGNORED)
 
 typedef struct signal_results {
+    /* Data for late processing */
     ccnt_t lo_prio_results[N_RUNS];
     ccnt_t hi_prio_results[N_RUNS];
-    ccnt_t overhead[N_RUNS];
     ccnt_t hi_prio_average[N_RUNS][NUM_AVERAGE_EVENTS];
-    /* Parameters intrinsic to early processing */
+    ccnt_t overhead[N_RUNS]; /* "overhead" is used by early processing as well */
+    /* Data for early processing */
     ccnt_t lo_sum; /* sum of samples */
     ccnt_t lo_sum2; /* sum of squared samples */
     ccnt_t lo_num; /* number of samples to process */
     ccnt_t overhead_min; /* min overhead found in "overhead" array */
+    /* array required by report output function
+    Zeros, but can be used for diagnostic data */
+    ccnt_t diag_results[N_RUNS]; /* array required by report output function */
 } signal_results_t;

--- a/libsel4benchsupport/include/sync.h
+++ b/libsel4benchsupport/include/sync.h
@@ -44,6 +44,17 @@ typedef struct sync_results {
 
     ccnt_t producer_to_consumer[N_PROD_CONS_BENCHMARKS][N_RUNS];
     ccnt_t consumer_to_producer[N_PROD_CONS_BENCHMARKS][N_RUNS];
+
+    /* Data for early processing */
+    ccnt_t producer_to_consumer_ep_sum;
+    ccnt_t producer_to_consumer_ep_sum2;
+    ccnt_t producer_to_consumer_ep_num;
+    ccnt_t producer_to_consumer_ep[N_RUNS];
+
+    ccnt_t consumer_to_producer_ep_sum;
+    ccnt_t consumer_to_producer_ep_sum2;
+    ccnt_t consumer_to_producer_ep_num;
+    ccnt_t consumer_to_producer_ep[N_RUNS];
 } sync_results_t;
 
 typedef void (*helper_func_t)(int argc, char *argv[]);

--- a/libsel4benchsupport/src/support.c
+++ b/libsel4benchsupport/src/support.c
@@ -9,6 +9,7 @@
 
 #include <autoconf.h>
 
+#include <sel4bench/sel4bench.h>
 #include <sel4platsupport/timer.h>
 #include <sel4platsupport/io.h>
 #include <sel4rpc/client.h>
@@ -49,6 +50,18 @@ static char ALIGN(0x1000) app_morecore_area[MORE_CORE_SIZE];
 #define ALLOCATOR_STATIC_POOL_SIZE ((1 << seL4_PageBits) * 20)
 static char allocator_mem_pool[ALLOCATOR_STATIC_POOL_SIZE];
 #define ALLOCMAN_VIRTUAL_SIZE BIT(20)
+
+/* early processing helper function */
+ccnt_t getMinOverhead(ccnt_t *overhead, seL4_Word overhead_size)
+{
+    ccnt_t min = -1;
+
+    for (int i = 0; i < overhead_size; i++) {
+        min = (overhead[i] < min) ? overhead[i] : min;
+    }
+
+    return min;
+}
 
 /* serial server */
 static serial_client_context_t context;


### PR DESCRIPTION
Applies the early processing methodology in #26 to a larger selection of benchmarks:

- IRQ benchmarks: Without context switch, With context switch
- Scheduler benchmarks: Thread yield, Process yield
- Signal benchmarks: Signal to high prio thread
- Fault benchmarks: Fault round trip, faulter -> fault handler, fault handler -> faulter
- Hardware benchmarks: Hardware null_syscall thread
- Sync benchmarks: Producer to consumer, Consumer to producer