### PR TITLE
Add documentation for adding a new benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,13 +76,15 @@ applications as well, since they'll be using an unexpected kernel build.
 
 
 # Adding a new benchmark
+
 Contributing a new benchmark to seL4bench requires a few steps:
+
 * Under `apps`, create a directory for your new benchmark and:
-    * Provide a CMakelists.txt file that defines a new executable.
+    * Provide a `CMakelists.txt` file that defines a new executable.
     * Provide a `src` folder that contains the source code for your
       benchmark.
 * Under `apps/sel4bench`:
-    * Update CMakeLists.txt to add your new benchmark to the list of
+    * Update `CMakeLists.txt` to add your new benchmark to the list of
       benchmarks.
     * Under `src`:
         * Update `benchmark.h` to include your generated config for your benchmark, as well as provide a function declaration that will act as the entry point for your benchmark.

--- a/README.md
+++ b/README.md
@@ -73,3 +73,22 @@ hardware tests.
 Since this benchmark will cause the kernel image to be an EL2 image, it
 will have an impact on the observed numbers for the other benchmark
 applications as well, since they'll be using an unexpected kernel build.
+
+
+# Adding a new benchmark
+Contributing a new benchmark to seL4bench requires a few steps:
+* Under `apps`, create a directory for your new benchmark and:
+    * Provide a CMakelists.txt file that defines a new executable.
+    * Provide a `src` folder that contains the source code for your
+      benchmark.
+* Under `apps/sel4bench`:
+    * Update CMakeLists.txt to add your new benchmark to the list of
+      benchmarks.
+    * Under `src`:
+        * Update `benchmark.h` to include your generated config for your benchmark, as well as provide a function declaration that will act as the entry point for your benchmark.
+        * Provide a `<benchmark_name>.c` file that implements the above function declaration. This function should return a `benchmark_t` struct. Construct this struct accordingly. The struct expects a function to process the results of the benchmark, which you should provide in this file as well
+        * Inside `main.c`, add your entry point function that was declared/defined above to the array of `benchmark_t` present.
+* Update `easy-settings.cmake` to add your new benchmark. You can define here whether the benchmark should be enabled by default or not.
+* Under `libsel4benchsupport/include`:
+    * Provide a `<benchmark_name.h>` file that provides any extra definitions that your benchmark may need. You will also generally provide a `benchmark_name_results_t` struct here, which will be used to store the results of your benchmark when processing.
+* Update `settings.cmake` to include your new benchmark.

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Contributing a new benchmark to seL4bench requires a few steps:
     * Update `CMakeLists.txt` to add your new benchmark to the list of
       benchmarks.
     * Under `src`:
-        * Update `benchmark.h` to include your generated config for your benchmark, as well as provide a function declaration that will act as the entry point for your benchmark.
+        * Update `benchmark.h` to include your generated config for your benchmark, and provide a function declaration that will act as the entry point for your benchmark.
         * Provide a `<benchmark_name>.c` file that implements the above function declaration. This function should return a `benchmark_t` struct. Construct this struct accordingly. The struct expects a function to process the results of the benchmark, which you should provide in this file as well
         * Inside `main.c`, add your entry point function that was declared/defined above to the array of `benchmark_t` present.
 * Update `easy-settings.cmake` to add your new benchmark. You can define here whether the benchmark should be enabled by default or not.

--- a/apps/sel4bench/CMakeLists.txt
+++ b/apps/sel4bench/CMakeLists.txt
@@ -72,6 +72,8 @@ add_subdirectory(../signal signal)
 add_subdirectory(../smp smp)
 add_subdirectory(../sync sync)
 add_subdirectory(../vcpu vcpu)
+# Add new benchmark applications here
+
 add_subdirectory(../../libsel4benchsupport libsel4benchsupport)
 
 config_option(Sel4Bench SEL4_BENCH "Enable seL4 benchmarking" DEFAULT ON)
@@ -106,6 +108,7 @@ if(Sel4Bench)
         smp_Config
         sel4benchsync_Config
         sel4benchvcpu_Config
+        # Add new benchmark configs here
     )
     include(rootserver)
     DeclareRootserver(sel4benchapp)

--- a/apps/sel4bench/src/benchmark.h
+++ b/apps/sel4bench/src/benchmark.h
@@ -106,6 +106,7 @@ benchmark_t *sync_benchmark_new(void);
 benchmark_t *page_mapping_benchmark_new(void);
 benchmark_t *smp_benchmark_new(void);
 benchmark_t *vcpu_benchmark_new(void);
+/* Add new benchmarks here */
 
 static inline void blank_init(UNUSED vka_t *vka, UNUSED simple_t *simple, UNUSED sel4utils_process_t *process)
 {

--- a/easy-settings.cmake
+++ b/easy-settings.cmake
@@ -26,6 +26,7 @@ set(ARM_HYP OFF CACHE BOOL "ARM EL2 hypervisor features on or off")
 set(MCS OFF CACHE BOOL "MCS kernel")
 
 # Set the list of benchmark applications to be included into the image
+# Add any new benchmark applications to this list
 
 # default is OFF
 set(HARDWARE OFF CACHE BOOL "Application to benchmark hardware-related operations")

--- a/settings.cmake
+++ b/settings.cmake
@@ -162,4 +162,6 @@ if(NOT Sel4benchAllowSettingsOverride)
     else()
         set(AppSyncBench OFF CACHE BOOL "" FORCE)
     endif()
+
+    # Add new app-specific configuration here
 endif()


### PR DESCRIPTION
Updated documentation to provide concise details on how to add new benchmarks to seL4bench. Code comments were added to highlight places in the code that require modification when adding a new benchmark