### PR TITLE
github: bump actions to node20

### DIFF
--- a/.github/workflows/sel4bench-pr.yml
+++ b/.github/workflows/sel4bench-pr.yml
@@ -45,7 +45,7 @@ jobs:
         xml: ${{ needs.code.outputs.xml }}
         march: ${{ matrix.march }}
     - name: Upload images
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: images-${{ matrix.march }}
         path: '*-images.tar.gz'
@@ -82,7 +82,7 @@ jobs:
     concurrency: sel4bench-hw-pr-${{ github.event.number }}-${{ strategy.job-index }}
     steps:
       - name: Get machine queue
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: seL4/machine_queue
           path: machine_queue
@@ -93,7 +93,7 @@ jobs:
         with:
           platform: ${{ matrix.platform }}
       - name: Download image
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: images-${{ steps.plat.outputs.march }}
       - name: Run
@@ -105,7 +105,7 @@ jobs:
         env:
           HW_SSH: ${{ secrets.HW_SSH }}
       - name: Upload results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           # funky expression below is to work around lack of ternary operator
           name: sel4bench-results-${{ matrix.platform }}${{ matrix.req != '' && format('-{0}', matrix.req) || '' }}

--- a/.github/workflows/sel4bench.yml
+++ b/.github/workflows/sel4bench.yml
@@ -47,7 +47,7 @@ jobs:
         xml: ${{ needs.code.outputs.xml }}
         march: ${{ matrix.march }}
     - name: Upload images
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: images-${{ matrix.march }}
         path: '*-images.tar.gz'
@@ -78,7 +78,7 @@ jobs:
     concurrency: sel4bench-hw-${{ strategy.job-index }}
     steps:
       - name: Get machine queue
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: seL4/machine_queue
           path: machine_queue
@@ -89,7 +89,7 @@ jobs:
         with:
           platform: ${{ matrix.platform }}
       - name: Download image
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: images-${{ steps.plat.outputs.march }}
       - name: Run
@@ -101,7 +101,7 @@ jobs:
         env:
           HW_SSH: ${{ secrets.HW_SSH }}
       - name: Upload results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           # funky expression below is to work around lack of ternary operator
           name: sel4bench-results-${{ matrix.platform }}${{ matrix.req != '' && format('-{0}', matrix.req) || '' }}
@@ -122,28 +122,28 @@ jobs:
       env:
         GH_SSH: ${{ secrets.CI_SSH }}
     - name: Check out website repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: seL4/website
         token: ${{ secrets.PRIV_REPO_TOKEN }}
     - name: Get results for web deployment (sabre)
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: sel4bench-results-sabre
     - name: Get results for web deployment (haswell)
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: sel4bench-results-pc99-haswell3
     - name: Get results for web deployment (skylake)
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: sel4bench-results-pc99-skylake
     - name: Get results for web deployment (tx1)
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: sel4bench-results-tx1
     - name: Get results for web deployment (hifive)
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: sel4bench-results-hifive
     - name: Generate web page


### PR DESCRIPTION
GitHub has started issuing warnings for node16 actions.