### PR TITLE
github: re-enable performance results deployment

### DIFF
--- a/.github/workflows/sel4bench.yml
+++ b/.github/workflows/sel4bench.yml
@@ -152,9 +152,9 @@ jobs:
         manifest_sha: ${{ steps.deploy.outputs.manifest_sha }}
     - name: Deploy web page
       run: |
-        mv home.pml content/About/Performance/
+        mv index.html content/About/Performance/
         git config user.name "seL4 CI"
         git config user.email "ci@sel4.systems"
-        git add content/About/Performance/home.pml
+        git add content/About/Performance/index.html
         git commit -s -m "CI: update performance results"
-        # git push origin master
+        git push origin master


### PR DESCRIPTION
Generate index.html instead of home.pml.

This should be merged after is https://github.com/seL4/ci-actions/pull/344 merged and the docker deployment for it has finished.