### PR TITLE
CI: cancel older concurrent PR runs

### DIFF
--- a/.github/workflows/sel4bench-pr.yml
+++ b/.github/workflows/sel4bench-pr.yml
@@ -4,7 +4,7 @@
 
 # Build and run sel4bench on pull requests
 
-name: seL4Bench PR
+name: seL4Bench-PR
 
 on:
   pull_request_target:
@@ -15,6 +15,12 @@ on:
 # downgrade permissions to read-only as you would have in a standard PR action
 permissions:
   contents: read
+
+# Cancel older runs of this workflow that are still not finished for the
+# current PR. This reduces the CI load.
+concurrency:
+  group: ${{ github.workflow }}-pr-${{ github.event.number }}
+  cancel-in-progress: true
 
 jobs:
   code:


### PR DESCRIPTION
Apply changes from https://github.com/seL4/seL4/pull/1178 here also.

Remove the space in the workflow name to ensure there are no side effects when using it as an identifier.