### PR TITLE
github: pin Ubuntu 22.04 for deployment step

### DIFF
--- a/.github/workflows/sel4bench.yml
+++ b/.github/workflows/sel4bench.yml
@@ -109,7 +109,7 @@ jobs:
   deploy:
     name: Deploy
     if: ${{ github.repository_owner == 'seL4' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [code, hw-run]
     steps:
     - name: Deploy manifest


### PR DESCRIPTION
Python 3.12 in Ubuntu 24.04 has incompatible packages.