### PR TITLE
revert changes that try setup malloc before libc runtime init

### DIFF
--- a/apps/fault/src/main.c
+++ b/apps/fault/src/main.c
@@ -11,9 +11,6 @@
 #include <sel4/sel4.h>
 #include <sel4bench/arch/sel4bench.h>
 #include <utils/ud.h>
-#include <sel4runtime.h>
-#include <muslcsys/vsyscall.h>
-#include <utils/attribute.h>
 
 #include <benchmark.h>
 #include <fault.h>
@@ -375,10 +372,12 @@ void measure_overhead(fault_results_t *results)
     }
 }
 
-static env_t *env;
-
-void CONSTRUCTOR(MUSLCSYS_WITH_VSYSCALL_PRIORITY) init_env(void)
+int main(int argc, char **argv)
 {
+    env_t *env;
+    UNUSED int error;
+    fault_results_t *results;
+
     static size_t object_freq[seL4_ObjectTypeCount] = {
         [seL4_TCBObject] = 2,
         [seL4_EndpointObject] = 2,
@@ -388,18 +387,7 @@ void CONSTRUCTOR(MUSLCSYS_WITH_VSYSCALL_PRIORITY) init_env(void)
 #endif
     };
 
-    env = benchmark_get_env(
-              sel4runtime_argc(),
-              sel4runtime_argv(),
-              sizeof(fault_results_t),
-              object_freq
-          );
-}
-
-int main(int argc, char **argv)
-{
-    UNUSED int error;
-    fault_results_t *results;
+    env = benchmark_get_env(argc, argv, sizeof(fault_results_t), object_freq);
     results = (fault_results_t *) env->results;
 
     sel4bench_init();

--- a/apps/hardware/src/main.c
+++ b/apps/hardware/src/main.c
@@ -10,9 +10,6 @@
 
 #include <sel4/sel4.h>
 #include <sel4bench/arch/sel4bench.h>
-#include <sel4runtime.h>
-#include <muslcsys/vsyscall.h>
-#include <utils/attribute.h>
 
 #include <benchmark.h>
 #include <hardware.h>
@@ -68,25 +65,14 @@ void measure_nullsyscall_ep(hardware_results_t *results)
     results->nullSyscall_ep_num = N_RUNS - N_IGNORED;
 }
 
-static env_t *env;
-
-void CONSTRUCTOR(MUSLCSYS_WITH_VSYSCALL_PRIORITY) init_env(void)
-{
-    static size_t object_freq[seL4_ObjectTypeCount] = {0};
-
-    env = benchmark_get_env(
-              sel4runtime_argc(),
-              sel4runtime_argv(),
-              sizeof(hardware_results_t),
-              object_freq
-          );
-}
-
 int main(int argc, char **argv)
 {
+    env_t *env;
     UNUSED int error;
     hardware_results_t *results;
 
+    static size_t object_freq[seL4_ObjectTypeCount] = {0};
+    env = benchmark_get_env(argc, argv, sizeof(hardware_results_t), object_freq);
     results = (hardware_results_t *) env->results;
 
     sel4bench_init();

--- a/apps/ipc/src/main.c
+++ b/apps/ipc/src/main.c
@@ -21,9 +21,6 @@
 #include <string.h>
 #include <utils/util.h>
 #include <vka/vka.h>
-#include <sel4runtime.h>
-#include <muslcsys/vsyscall.h>
-#include <utils/attribute.h>
 
 #include <benchmark.h>
 #include <ipc.h>
@@ -358,10 +355,12 @@ void run_bench(env_t *env, cspacepath_t result_ep_path, seL4_CPtr ep,
     timing_destroy();
 }
 
-static env_t *env;
-
-void CONSTRUCTOR(MUSLCSYS_WITH_VSYSCALL_PRIORITY) init_env(void)
+int main(int argc, char **argv)
 {
+    env_t *env;
+    vka_object_t ep, result_ep;
+    cspacepath_t ep_path, result_ep_path;
+
     static size_t object_freq[seL4_ObjectTypeCount] = {
         [seL4_TCBObject] = 4,
         [seL4_EndpointObject] = 2,
@@ -371,19 +370,7 @@ void CONSTRUCTOR(MUSLCSYS_WITH_VSYSCALL_PRIORITY) init_env(void)
 #endif
     };
 
-    env = benchmark_get_env(
-              sel4runtime_argc(),
-              sel4runtime_argv(),
-              sizeof(ipc_results_t),
-              object_freq
-          );
-}
-
-int main(int argc, char **argv)
-{
-    vka_object_t ep, result_ep;
-    cspacepath_t ep_path, result_ep_path;
-
+    env = benchmark_get_env(argc, argv, sizeof(ipc_results_t), object_freq);
     ipc_results_t *results = (ipc_results_t *) env->results;
 
     /* allocate benchmark endpoint - the IPC's that we benchmark

--- a/apps/irq/src/main.c
+++ b/apps/irq/src/main.c
@@ -7,9 +7,6 @@
 #include <sel4benchirq/gen_config.h>
 
 #include <stdio.h>
-#include <sel4runtime.h>
-#include <muslcsys/vsyscall.h>
-#include <utils/attribute.h>
 
 #include <sel4platsupport/timer.h>
 #include <sel4platsupport/plat/timer.h>
@@ -29,24 +26,13 @@ void abort(void)
     benchmark_finished(EXIT_FAILURE);
 }
 
-static env_t *env;
-
-void CONSTRUCTOR(MUSLCSYS_WITH_VSYSCALL_PRIORITY) init_env(void)
-{
-    static size_t object_freq[seL4_ObjectTypeCount] = {0};
-
-    env = benchmark_get_env(
-              sel4runtime_argc(),
-              sel4runtime_argv(),
-              sizeof(irq_results_t),
-              object_freq
-          );
-}
-
 int main(int argc, char **argv)
 {
+    env_t *env;
     irq_results_t *results;
 
+    static size_t object_freq[seL4_ObjectTypeCount] = {0};
+    env = benchmark_get_env(argc, argv, sizeof(irq_results_t), object_freq);
     results = (irq_results_t *) env->results;
 
     ZF_LOGF_IF(timer_periodic(env->timeout_timer->timer, INTERRUPT_PERIOD_NS) != 0,

--- a/apps/irquser/src/main.c
+++ b/apps/irquser/src/main.c
@@ -6,9 +6,6 @@
 #include <autoconf.h>
 #include <sel4benchirquser/gen_config.h>
 #include <stdio.h>
-#include <sel4runtime.h>
-#include <muslcsys/vsyscall.h>
-#include <utils/attribute.h>
 
 #include <sel4platsupport/timer.h>
 #include <sel4platsupport/irq.h>
@@ -110,10 +107,12 @@ void ticker_fn_ep(int argc, char **argv)
     seL4_Send(done_ep, seL4_MessageInfo_new(0, 0, 0, 0));
 }
 
-static env_t *env;
-
-void CONSTRUCTOR(MUSLCSYS_WITH_VSYSCALL_PRIORITY) init_env(void)
+int main(int argc, char **argv)
 {
+    env_t *env;
+    irquser_results_t *results;
+    vka_object_t endpoint = {0};
+
     static size_t object_freq[seL4_ObjectTypeCount] = {
         [seL4_TCBObject] = 2,
         [seL4_EndpointObject] = 1,
@@ -123,19 +122,7 @@ void CONSTRUCTOR(MUSLCSYS_WITH_VSYSCALL_PRIORITY) init_env(void)
 #endif
     };
 
-    env = benchmark_get_env(
-              sel4runtime_argc(),
-              sel4runtime_argv(),
-              sizeof(irquser_results_t),
-              object_freq
-          );
-}
-
-int main(int argc, char **argv)
-{
-    irquser_results_t *results;
-    vka_object_t endpoint = {0};
-
+    env = benchmark_get_env(argc, argv, sizeof(irquser_results_t), object_freq);
     benchmark_init_timer(env);
     results = (irquser_results_t *) env->results;
 

--- a/apps/page_mapping/src/main.c
+++ b/apps/page_mapping/src/main.c
@@ -9,9 +9,6 @@
 #include <sel4bench/arch/sel4bench.h>
 #include <benchmark.h>
 #include <page_mapping.h>
-#include <sel4runtime.h>
-#include <muslcsys/vsyscall.h>
-#include <utils/attribute.h>
 
 #define START_ADDR 0x60000000
 #define NUM_ARGS 3
@@ -239,10 +236,14 @@ static void measure_overhead(page_mapping_results_t *results)
     sel4bench_destroy();
 }
 
-static env_t *env;
-
-void CONSTRUCTOR(MUSLCSYS_WITH_VSYSCALL_PRIORITY) init_env(void)
+int main(int argc, char *argv[])
 {
+    env_t *env;
+    page_mapping_results_t *results;
+    vka_object_t result_ep, untyped_obj;
+    cspacepath_t result_ep_path, untyped_path;
+    helper_thread_t proc;
+
     static size_t object_freq[seL4_ObjectTypeCount] = {
         [seL4_TCBObject] = 1,
         [seL4_EndpointObject] = 1,
@@ -252,21 +253,8 @@ void CONSTRUCTOR(MUSLCSYS_WITH_VSYSCALL_PRIORITY) init_env(void)
 #endif
     };
 
-    env = benchmark_get_env(
-              sel4runtime_argc(),
-              sel4runtime_argv(),
-              sizeof(page_mapping_results_t),
-              object_freq
-          );
-}
-
-int main(int argc, char *argv[])
-{
-    page_mapping_results_t *results;
-    vka_object_t result_ep, untyped_obj;
-    cspacepath_t result_ep_path, untyped_path;
-    helper_thread_t proc;
-
+    env = benchmark_get_env(argc, argv, sizeof(page_mapping_results_t),
+                            object_freq);
     results = (page_mapping_results_t *)env->results;
 
     /* allocate result end point */

--- a/apps/scheduler/src/main.c
+++ b/apps/scheduler/src/main.c
@@ -5,9 +5,6 @@
  */
 #include <autoconf.h>
 #include <sel4benchscheduler/gen_config.h>
-#include <sel4runtime.h>
-#include <muslcsys/vsyscall.h>
-#include <utils/attribute.h>
 #include <stdio.h>
 
 #include <sel4/sel4.h>
@@ -395,10 +392,13 @@ void benchmark_yield_average(ccnt_t results[N_RUNS][NUM_AVERAGE_EVENTS])
     }
 }
 
-static env_t *env;
-
-void CONSTRUCTOR(MUSLCSYS_WITH_VSYSCALL_PRIORITY) init_env(void)
+int main(int argc, char **argv)
 {
+    env_t *env;
+    UNUSED int error;
+    vka_object_t done_ep, produce, consume;
+    scheduler_results_t *results;
+
     static size_t object_freq[seL4_ObjectTypeCount] = {
         [seL4_TCBObject] = 6,
 #ifdef CONFIG_KERNEL_MCS
@@ -409,20 +409,7 @@ void CONSTRUCTOR(MUSLCSYS_WITH_VSYSCALL_PRIORITY) init_env(void)
         [seL4_NotificationObject] = 2,
     };
 
-    env = benchmark_get_env(
-              sel4runtime_argc(),
-              sel4runtime_argv(),
-              sizeof(scheduler_results_t),
-              object_freq
-          );
-}
-
-int main(int argc, char **argv)
-{
-    UNUSED int error;
-    vka_object_t done_ep, produce, consume;
-    scheduler_results_t *results;
-
+    env = benchmark_get_env(argc, argv, sizeof(scheduler_results_t), object_freq);
     results = (scheduler_results_t *) env->results;
 
     sel4bench_init();

--- a/apps/sel4bench/src/main.c
+++ b/apps/sel4bench/src/main.c
@@ -315,7 +315,6 @@ extern vspace_t *muslc_this_vspace;
 extern reservation_t muslc_brk_reservation;
 extern void *muslc_brk_reservation_start;
 static allocman_t *allocman;
-static sel4utils_res_t malloc_res;
 
 static void CONSTRUCTOR(MUSLCSYS_WITH_VSYSCALL_PRIORITY)  init_malloc(void)
 {
@@ -339,6 +338,7 @@ static void CONSTRUCTOR(MUSLCSYS_WITH_VSYSCALL_PRIORITY)  init_malloc(void)
                                                            &global_env.vka, info);
 
     /* set up malloc */
+    sel4utils_res_t malloc_res;
     error = sel4utils_reserve_range_no_alloc(&global_env.vspace, &malloc_res, seL4_LargePageBits, seL4_AllRights, 1,
                                              &muslc_brk_reservation_start);
     muslc_this_vspace = &global_env.vspace;

--- a/apps/sel4bench/src/main.c
+++ b/apps/sel4bench/src/main.c
@@ -26,11 +26,9 @@
 #include <stdio.h>
 #include <string.h>
 #include <utils/util.h>
-#include <utils/attribute.h>
 #include <vka/object.h>
 #include <vka/capops.h>
 #include <libfdt.h>
-#include <muslcsys/vsyscall.h>
 
 #include <ipc.h>
 #include <benchmark_types.h>
@@ -312,12 +310,14 @@ void *main_continued(void *arg)
 extern vspace_t *muslc_this_vspace;
 extern reservation_t muslc_brk_reservation;
 extern void *muslc_brk_reservation_start;
-static allocman_t *allocman;
 
-static void CONSTRUCTOR(MUSLCSYS_WITH_VSYSCALL_PRIORITY)  init_malloc(void)
+int main(void)
 {
     seL4_BootInfo *info;
+    allocman_t *allocman;
+    UNUSED reservation_t virtual_reservation;
     UNUSED int error;
+    void *vaddr;
 
     info  = platsupport_get_bootinfo();
     simple_default_init_bootinfo(&global_env.simple, info);
@@ -340,13 +340,6 @@ static void CONSTRUCTOR(MUSLCSYS_WITH_VSYSCALL_PRIORITY)  init_malloc(void)
     muslc_this_vspace = &global_env.vspace;
     muslc_brk_reservation.res = &malloc_res;
     ZF_LOGF_IF(error, "Failed to set up dynamic malloc");
-}
-
-int main(void)
-{
-    UNUSED reservation_t virtual_reservation;
-    UNUSED int error;
-    void *vaddr;
 
     virtual_reservation = vspace_reserve_range(&global_env.vspace, ALLOCATOR_VIRTUAL_POOL_SIZE, seL4_AllRights,
                                                1, &vaddr);

--- a/apps/sel4bench/src/main.c
+++ b/apps/sel4bench/src/main.c
@@ -12,8 +12,6 @@
 #include <allocman/vka.h>
 #include <assert.h>
 
-#include <sel4runtime.h>
-
 #include <simple/simple.h>
 #include <simple-default/simple-default.h>
 
@@ -351,17 +349,8 @@ static void CONSTRUCTOR(MUSLCSYS_WITH_VSYSCALL_PRIORITY)  init_malloc(void)
     bootstrap_configure_virtual_pool(allocman, vaddr, ALLOCATOR_VIRTUAL_POOL_SIZE, simple_get_pd(&global_env.simple));
 }
 
-/* When the root task exists, it should simply suspend itself */
-static void sel4bench_exit(int code)
-{
-    seL4_TCB_Suspend(seL4_CapInitThreadTCB);
-}
-
 int main(void)
 {
-    /* Set exit handler */
-    sel4runtime_set_exit(sel4bench_exit);
-
     UNUSED int error;
 
     /* init serial */

--- a/apps/sel4bench/src/main.c
+++ b/apps/sel4bench/src/main.c
@@ -318,8 +318,6 @@ static void CONSTRUCTOR(MUSLCSYS_WITH_VSYSCALL_PRIORITY)  init_malloc(void)
 {
     seL4_BootInfo *info;
     UNUSED int error;
-    UNUSED reservation_t virtual_reservation;
-    void *vaddr;
 
     info  = platsupport_get_bootinfo();
     simple_default_init_bootinfo(&global_env.simple, info);
@@ -342,16 +340,18 @@ static void CONSTRUCTOR(MUSLCSYS_WITH_VSYSCALL_PRIORITY)  init_malloc(void)
     muslc_this_vspace = &global_env.vspace;
     muslc_brk_reservation.res = &malloc_res;
     ZF_LOGF_IF(error, "Failed to set up dynamic malloc");
+}
+
+int main(void)
+{
+    UNUSED reservation_t virtual_reservation;
+    UNUSED int error;
+    void *vaddr;
 
     virtual_reservation = vspace_reserve_range(&global_env.vspace, ALLOCATOR_VIRTUAL_POOL_SIZE, seL4_AllRights,
                                                1, &vaddr);
     assert(virtual_reservation.res);
     bootstrap_configure_virtual_pool(allocman, vaddr, ALLOCATOR_VIRTUAL_POOL_SIZE, simple_get_pd(&global_env.simple));
-}
-
-int main(void)
-{
-    UNUSED int error;
 
     /* init serial */
     platsupport_serial_setup_simple(&global_env.vspace, &global_env.simple, &global_env.vka);

--- a/apps/sel4bench/src/main.c
+++ b/apps/sel4bench/src/main.c
@@ -12,6 +12,8 @@
 #include <allocman/vka.h>
 #include <assert.h>
 
+#include <sel4runtime.h>
+
 #include <simple/simple.h>
 #include <simple-default/simple-default.h>
 
@@ -310,6 +312,12 @@ void *main_continued(void *arg)
 extern vspace_t *muslc_this_vspace;
 extern reservation_t muslc_brk_reservation;
 extern void *muslc_brk_reservation_start;
+/* When the root task exists, it should simply suspend itself */
+static void sel4bench_exit(int code)
+{
+    seL4_TCB_Suspend(seL4_CapInitThreadTCB);
+}
+
 
 int main(void)
 {
@@ -318,6 +326,9 @@ int main(void)
     UNUSED reservation_t virtual_reservation;
     UNUSED int error;
     void *vaddr;
+
+    /* Set exit handler */
+    sel4runtime_set_exit(sel4bench_exit);
 
     info  = platsupport_get_bootinfo();
     simple_default_init_bootinfo(&global_env.simple, info);

--- a/apps/sel4bench/src/main.c
+++ b/apps/sel4bench/src/main.c
@@ -352,6 +352,10 @@ int main(void)
     muslc_brk_reservation.res = &malloc_res;
     ZF_LOGF_IF(error, "Failed to set up dynamic malloc");
 
+    // NOTE: MALLOC Cannot be called before this part of the process bootstrap.
+    // muslc_thsi_vspace & muslc_brk_reservation are used by the libsel4muslcsys/morecore allocator that provides
+    // memory for malloc to use.
+
     virtual_reservation = vspace_reserve_range(&global_env.vspace, ALLOCATOR_VIRTUAL_POOL_SIZE, seL4_AllRights,
                                                1, &vaddr);
     assert(virtual_reservation.res);

--- a/apps/signal/src/main.c
+++ b/apps/signal/src/main.c
@@ -7,9 +7,6 @@
 #include <autoconf.h>
 #include <sel4benchsignal/gen_config.h>
 #include <stdio.h>
-#include <sel4runtime.h>
-#include <muslcsys/vsyscall.h>
-#include <utils/attribute.h>
 
 #include <sel4/sel4.h>
 #include <sel4bench/arch/sel4bench.h>
@@ -278,10 +275,13 @@ void measure_signal_overhead(seL4_CPtr ntfn, ccnt_t *results)
     }
 }
 
-static env_t *env;
-
-void CONSTRUCTOR(MUSLCSYS_WITH_VSYSCALL_PRIORITY) init_env(void)
+int main(int argc, char **argv)
 {
+    env_t *env;
+    UNUSED int error;
+    vka_object_t done_ep, ntfn;
+    signal_results_t *results;
+
     /* configure the slab allocator - we need 2 tcbs, 2 scs, 1 ntfn, 1 ep */
     static size_t object_freq[seL4_ObjectTypeCount] = {
         [seL4_TCBObject] = 2,
@@ -293,20 +293,7 @@ void CONSTRUCTOR(MUSLCSYS_WITH_VSYSCALL_PRIORITY) init_env(void)
         [seL4_NotificationObject] = 1,
     };
 
-    env = benchmark_get_env(
-              sel4runtime_argc(),
-              sel4runtime_argv(),
-              sizeof(signal_results_t),
-              object_freq
-          );
-}
-
-int main(int argc, char **argv)
-{
-    UNUSED int error;
-    vka_object_t done_ep, ntfn;
-    signal_results_t *results;
-
+    env = benchmark_get_env(argc, argv, sizeof(signal_results_t), object_freq);
     results = (signal_results_t *) env->results;
 
     sel4bench_init();

--- a/apps/smp/src/main.c
+++ b/apps/smp/src/main.c
@@ -6,9 +6,6 @@
 
 #include <autoconf.h>
 #include <smp/gen_config.h>
-#include <sel4runtime.h>
-#include <muslcsys/vsyscall.h>
-#include <utils/attribute.h>
 
 #include <sel4platsupport/timer.h>
 #include <utils/time.h>
@@ -223,29 +220,18 @@ static void benchmark_multicore_ipc_throughput(env_t *env, smp_results_t *result
     }
 }
 
-static env_t *env;
-
-void CONSTRUCTOR(MUSLCSYS_WITH_VSYSCALL_PRIORITY) init_env(void)
-{
-    static size_t object_freq[seL4_ObjectTypeCount] = {
-        [seL4_TCBObject] = 2 * CONFIG_MAX_NUM_NODES,
-        [seL4_EndpointObject] = CONFIG_MAX_NUM_NODES,
-    };
-
-    env = benchmark_get_env(
-              sel4runtime_argc(),
-              sel4runtime_argv(),
-              sizeof(smp_results_t),
-              object_freq
-          );
-}
-
 int main(int argc, char *argv[])
 {
+    env_t *env;
     UNUSED int error;
     smp_results_t *results;
     int nr_cores;
 
+    static size_t object_freq[seL4_ObjectTypeCount] = {
+        [seL4_TCBObject] = 2 * CONFIG_MAX_NUM_NODES,
+        [seL4_EndpointObject] = CONFIG_MAX_NUM_NODES,
+    };
+    env = benchmark_get_env(argc, argv, sizeof(smp_results_t), object_freq);
     benchmark_init_timer(env);
     results = (smp_results_t *) env->results;
     nr_cores = simple_get_core_count(&env->simple);

--- a/apps/vcpu/src/main.c
+++ b/apps/vcpu/src/main.c
@@ -43,9 +43,6 @@
 #include <utils/attribute.h>
 #include <vka/vka.h>
 #include <vka/object_capops.h>
-#include <sel4runtime.h>
-#include <muslcsys/vsyscall.h>
-#include <utils/attribute.h>
 
 #include <benchmark.h>
 #include <vcpu.h>
@@ -598,10 +595,13 @@ static ccnt_t get_ccnt_read_overhead_avg(void)
     return avg_overhead;
 }
 
-static env_t *env;
-
-void CONSTRUCTOR(MUSLCSYS_WITH_VSYSCALL_PRIORITY) init_env(void)
+int main(int argc, char **argv)
 {
+    int err, n_guests_exited;
+    env_t *env;
+    cspacepath_t ep_path, result_ep_path;
+    vcpu_benchmark_overall_results_t *overall_results;
+
     static size_t object_freq[seL4_ObjectTypeCount] = {
         [seL4_TCBObject] = 4,
         [seL4_EndpointObject] = 2,
@@ -611,20 +611,9 @@ void CONSTRUCTOR(MUSLCSYS_WITH_VSYSCALL_PRIORITY) init_env(void)
 #endif
     };
 
-    env = benchmark_get_env(
-              sel4runtime_argc(),
-              sel4runtime_argv(),
-              sizeof(vcpu_benchmark_overall_results_t),
-              object_freq
-          );
-}
-
-int main(int argc, char **argv)
-{
-    int err, n_guests_exited;
-    cspacepath_t ep_path, result_ep_path;
-    vcpu_benchmark_overall_results_t *overall_results;
-
+    env = benchmark_get_env(argc, argv,
+                            sizeof(vcpu_benchmark_overall_results_t),
+                            object_freq);
     overall_results = env->results;
 
     sel4bench_init();

--- a/settings.cmake
+++ b/settings.cmake
@@ -59,6 +59,13 @@ if(NOT Sel4benchAllowSettingsOverride)
 
     endif()
 
+    if (KernelSel4ArchAarch32)
+        set(KernelArmTLSReg tpidruro CACHE STRING "" FORCE)
+    endif()
+    if (KernelSel4ArchAarch64)
+        set(KernelArmTLSReg tpidru CACHE STRING "" FORCE)
+    endif()
+
     # Setup flags for RELEASE (performance optimized builds)
     ApplyCommonReleaseVerificationSettings(${RELEASE} OFF)
     # This option is controlled by ApplyCommonReleaseVerificationSettings


### PR DESCRIPTION
C library is not expected to work before the c runtime init has occurred. Some of these setup functions that were called in the constructors rely on c library to be initialized first.  

malloc definitely needs the C runtime to be initialized first otherwise it can return corrupt values.