### PR TITLE
Use seL4_TCBFlag_fpuDisabled for tests like IPC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,17 @@ if((NOT Sel4benchAllowSettingsOverride) AND (KernelArchARM OR KernelArchRiscV))
 endif()
 elfloader_import_project()
 
+# Avoid compilers from using SIMD instructions for integer code.
+# If the program faults on a SIMD instruction for your platform,
+# update this code or find another work-around.
+function(general_regs_only target)
+    include(CheckCCompilerFlag OPTIONAL)
+    check_c_compiler_flag(-mgeneral-regs-only HAS_GENERAL_REGS_ONLY)
+    if(HAS_GENERAL_REGS_ONLY)
+        target_compile_options(${target} PRIVATE -mgeneral-regs-only)
+    endif()
+endfunction()
+
 add_subdirectory(apps/sel4bench)
 
 include(simulation)

--- a/apps/fault/CMakeLists.txt
+++ b/apps/fault/CMakeLists.txt
@@ -50,3 +50,5 @@ target_link_libraries(
 if(AppFaultBench)
     set_property(GLOBAL APPEND PROPERTY sel4benchapps_property "$<TARGET_FILE:fault>")
 endif()
+
+general_regs_only(fault)

--- a/apps/fault/src/main.c
+++ b/apps/fault/src/main.c
@@ -323,6 +323,7 @@ static void run_fault_benchmark(env_t *env, fault_results_t *results)
 
     /* create fault handler */
     benchmark_configure_thread(env, seL4_CapNull, seL4_MinPrio, "fault handler", &fault_handler);
+    configure_fpu(fault_handler.tcb.cptr, false);
     sel4utils_create_word_args(handler_args, handler_argv, N_HANDLER_ARGS,
                                fault_endpoint.cptr, (seL4_Word) &start,
                                (seL4_Word) results, done_ep.cptr, fault_handler.reply.cptr);

--- a/apps/ipc/CMakeLists.txt
+++ b/apps/ipc/CMakeLists.txt
@@ -93,3 +93,5 @@ target_link_libraries(
 if(AppIpcBench)
     set_property(GLOBAL APPEND PROPERTY sel4benchapps_property "$<TARGET_FILE:ipc>")
 endif()
+
+general_regs_only(ipc)

--- a/apps/ipc/src/main.c
+++ b/apps/ipc/src/main.c
@@ -415,6 +415,8 @@ int main(int argc, char **argv)
         ZF_LOGI("--------------------------------------------------\n");
         for (j = 0; j < ARRAY_SIZE(benchmark_params); j++) {
             const struct benchmark_params *params = &benchmark_params[j];
+            seL4_CPtr client_tcb = client.process.thread.tcb.cptr;
+
             ZF_LOGI("%s\t: IPC duration (%s), client prio: %3d server prio %3d, %s vspace, %s, length %2d\n",
                     params->name,
                     params->direction == DIR_TO ? "client --> server" : "server --> client",
@@ -422,17 +424,26 @@ int main(int argc, char **argv)
                     params->same_vspace ? "same" : "diff",
                     (config_set(CONFIG_KERNEL_MCS) && params->passive) ? "passive" : "active", params->length);
 
+            /* Enable client FPU explicitly, even though it's on by default: */
+            configure_fpu(client_tcb, true);
+
             /* set up client for benchmark */
-            int error = seL4_TCB_SetPriority(client.process.thread.tcb.cptr, auth, params->client_prio);
+            int error = seL4_TCB_SetPriority(client_tcb, auth, params->client_prio);
             ZF_LOGF_IF(error, "Failed to set client prio");
             client.process.entry_point = bench_funcs[params->client_fn];
 
             if (params->same_vspace) {
-                error = seL4_TCB_SetPriority(server_thread.process.thread.tcb.cptr, auth, params->server_prio);
+                seL4_CPtr tcb = server_thread.process.thread.tcb.cptr;
+
+                configure_fpu(tcb, params->server_fpu);
+                error = seL4_TCB_SetPriority(tcb, auth, params->server_prio);
                 assert(error == seL4_NoError);
                 server_thread.process.entry_point = bench_funcs[params->server_fn];
             } else {
-                error = seL4_TCB_SetPriority(server_process.process.thread.tcb.cptr, auth, params->server_prio);
+                seL4_CPtr tcb = server_process.process.thread.tcb.cptr;
+
+                configure_fpu(tcb, params->server_fpu);
+                error = seL4_TCB_SetPriority(tcb, auth, params->server_prio);
                 assert(error == seL4_NoError);
                 server_process.process.entry_point = bench_funcs[params->server_fn];
             }

--- a/apps/irquser/CMakeLists.txt
+++ b/apps/irquser/CMakeLists.txt
@@ -44,3 +44,5 @@ target_link_libraries(
 if(AppIrqUserBench)
     set_property(GLOBAL APPEND PROPERTY sel4benchapps_property "$<TARGET_FILE:irquser>")
 endif()
+
+general_regs_only(irquser)

--- a/apps/signal/CMakeLists.txt
+++ b/apps/signal/CMakeLists.txt
@@ -29,3 +29,5 @@ target_link_libraries(signal sel4_autoconf sel4benchsignal_Config sel4benchsuppo
 if(AppSignalBench)
     set_property(GLOBAL APPEND PROPERTY sel4benchapps_property "$<TARGET_FILE:signal>")
 endif()
+
+general_regs_only(signal)

--- a/apps/signal/src/main.c
+++ b/apps/signal/src/main.c
@@ -218,6 +218,10 @@ static void benchmark(env_t *env, seL4_CPtr ep, seL4_CPtr ntfn, signal_results_t
     benchmark_configure_thread(env, ep, seL4_MaxPrio - 1, "signal", &signal.thread);
     benchmark_configure_thread(env, ep, seL4_MaxPrio - 1, "signal early", &signal_early_proc.thread);
 
+    configure_fpu(wait.thread.tcb.cptr, false);
+    configure_fpu(signal.thread.tcb.cptr, false);
+    configure_fpu(signal_early_proc.thread.tcb.cptr, false);
+
     sel4utils_create_word_args(wait.argv_strings, wait.argv, wait.argc, ntfn, ep, (seL4_Word) &end);
 
     sel4utils_create_word_args(signal.argv_strings, signal.argv, signal.argc, ntfn,

--- a/libsel4benchsupport/include/benchmark.h
+++ b/libsel4benchsupport/include/benchmark.h
@@ -191,3 +191,6 @@ void send_result(seL4_CPtr ep, ccnt_t result);
  * @param ep The endpoint the result will be received from
  */
 ccnt_t get_result(seL4_CPtr ep);
+
+/* Enable or disable the FPU for a task */
+void configure_fpu(seL4_CPtr tcb, bool fpu_on);

--- a/libsel4benchsupport/include/ipc.h
+++ b/libsel4benchsupport/include/ipc.h
@@ -61,6 +61,7 @@ typedef struct benchmark_params {
     enum overheads overhead_id;
     /* if CONFIG_KERNEL_MCS, should the server be passive? */
     bool passive;
+    bool server_fpu;
 } benchmark_params_t;
 
 struct overhead_benchmark_params {
@@ -82,6 +83,7 @@ static const benchmark_params_t benchmark_params[] = {
         .length = 0,
         .overhead_id = CALL_OVERHEAD,
         .passive = true,
+        .server_fpu = false,
     },
     /* ReplyRecv fastpath between server and client in the same address space */
     {
@@ -95,6 +97,7 @@ static const benchmark_params_t benchmark_params[] = {
         .length = 0,
         .overhead_id = REPLY_RECV_OVERHEAD,
         .passive = true,
+        .server_fpu = false,
     },
     /* Call fastpath between client and server in different address spaces */
     {
@@ -108,6 +111,21 @@ static const benchmark_params_t benchmark_params[] = {
         .length = 0,
         .overhead_id = CALL_OVERHEAD,
         .passive = true,
+        .server_fpu = false,
+    },
+    /* Call fastpath between client and FPU enabled server in different address spaces */
+    {
+        .name        = "seL4_Call (FPU)",
+        .direction   = DIR_TO,
+        .client_fn   = IPC_CALL_FUNC2,
+        .server_fn   = IPC_REPLYRECV_FUNC2,
+        .same_vspace = false,
+        .client_prio = seL4_MaxPrio - 1,
+        .server_prio = seL4_MaxPrio - 1,
+        .length = 0,
+        .overhead_id = CALL_OVERHEAD,
+        .passive = true,
+        .server_fpu = true,
     },
     /* ReplyRecv fastpath between server and client in different address spaces */
     {
@@ -121,6 +139,21 @@ static const benchmark_params_t benchmark_params[] = {
         .length = 0,
         .overhead_id = REPLY_RECV_OVERHEAD,
         .passive = true,
+        .server_fpu = false,
+    },
+    /* ReplyRecv fastpath between FPU enabled server and client in different address spaces */
+    {
+        .name        = "seL4_ReplyRecv (FPU)",
+        .direction   = DIR_FROM,
+        .client_fn   = IPC_CALL_FUNC,
+        .server_fn   = IPC_REPLYRECV_FUNC,
+        .same_vspace = false,
+        .client_prio = seL4_MaxPrio - 1,
+        .server_prio = seL4_MaxPrio - 1,
+        .length = 0,
+        .overhead_id = REPLY_RECV_OVERHEAD,
+        .passive = true,
+        .server_fpu = true,
     },
     /* Send slowpath (no fastpath for send) same prio client-server, different address space */
     {
@@ -132,7 +165,9 @@ static const benchmark_params_t benchmark_params[] = {
         .client_prio = seL4_MaxPrio - 2,
         .server_prio = seL4_MaxPrio - 1,
         .length = 0,
-        .overhead_id = SEND_OVERHEAD
+        .overhead_id = SEND_OVERHEAD,
+        .passive = false,
+        .server_fpu = false,
     },
     /* Call slowpath, long IPC (10), same prio client to server, different address space */
     {
@@ -144,7 +179,9 @@ static const benchmark_params_t benchmark_params[] = {
         .client_prio = seL4_MaxPrio - 1,
         .server_prio = seL4_MaxPrio - 1,
         .length = 10,
-        .overhead_id = CALL_10_OVERHEAD
+        .overhead_id = CALL_10_OVERHEAD,
+        .passive = false,
+        .server_fpu = false,
     },
     /* ReplyRecv slowpath, long IPC (10), same prio server to client, on the slowpath, different address space */
     {
@@ -156,7 +193,9 @@ static const benchmark_params_t benchmark_params[] = {
         .client_prio = seL4_MaxPrio - 1,
         .server_prio = seL4_MaxPrio - 1,
         .length = 10,
-        .overhead_id = REPLY_RECV_10_OVERHEAD
+        .overhead_id = REPLY_RECV_10_OVERHEAD,
+        .passive = false,
+        .server_fpu = false,
     }
 };
 

--- a/libsel4benchsupport/src/support.c
+++ b/libsel4benchsupport/src/support.c
@@ -651,3 +651,16 @@ ccnt_t get_result(seL4_CPtr ep)
 
     return result;
 }
+
+void configure_fpu(seL4_CPtr tcb, bool fpu_on)
+{
+    seL4_TCB_SetFlags_t res;
+    seL4_TCBFlag flags_clear = seL4_TCBFlag_NoFlag, flags_set = seL4_TCBFlag_fpuDisabled;
+
+    if (fpu_on) {
+        flags_clear = seL4_TCBFlag_fpuDisabled;
+        flags_set = seL4_TCBFlag_NoFlag;
+    }
+    res = seL4_TCB_SetFlags(tcb, flags_clear, flags_set);
+    assert(res.error == seL4_NoError);
+}


### PR DESCRIPTION
Also disable the FPU for fault, signal and irquser tests.

And add one IPC test with FPU in the server enabled.

This to get comparable performance numbers to before trap based
FPU state switching got replaced by a TCB flags based approach.

Remove CONFIG_FPU_MAX_RESTORES_SINCE_SWITCH code:
Config option is gone since trap based FPU switching has
been replaced by a TCB flag based one.

Fixes issue #61.

Test with https://github.com/seL4/seL4/pull/1574