### PR TITLE
Add early processing to scheduler tests. Stop saving empty results for early processing.

### DIFF
--- a/apps/scheduler/src/main.c
+++ b/apps/scheduler/src/main.c
@@ -16,7 +16,7 @@
 #define NOPS ""
 
 #include <arch/signal.h>
-#define N_LOW_ARGS 5
+#define N_LOW_ARGS 8
 #define N_HIGH_ARGS 4
 #define N_YIELD_ARGS 2
 
@@ -63,6 +63,38 @@ void low_fn(int argc, char **argv)
         results[i] = (end - *start);
         DO_REAL_SIGNAL(consume);
     }
+
+    /* signal completion */
+    seL4_Send(done_ep, seL4_MessageInfo_new(0, 0, 0, 0));
+    /* block */
+    seL4_Wait(produce, NULL);
+}
+
+void low_fn_ep(int argc, char **argv)
+{
+    assert(argc == N_LOW_ARGS);
+    seL4_CPtr produce = (seL4_CPtr) atol(argv[0]);
+    volatile ccnt_t *start = (volatile ccnt_t *) atol(argv[1]);
+    ccnt_t overhead = (ccnt_t) atol(argv[2]);
+    ccnt_t *out_sum = (ccnt_t *) atol(argv[3]);
+    ccnt_t *out_sum2 = (ccnt_t *) atol(argv[4]);
+    ccnt_t *out_num = (ccnt_t *) atol(argv[5]);
+    seL4_CPtr done_ep = (seL4_CPtr) atol(argv[6]);
+    seL4_CPtr consume = (seL4_CPtr) atol(argv[7]);
+
+    ccnt_t sum = 0, sum2 = 0;
+    DATACOLLECT_INIT();
+    for (seL4_Word i = 0; i < N_RUNS; i++) {
+        ccnt_t end;
+        DO_REAL_WAIT(produce);
+        SEL4BENCH_READ_CCNT(end);
+        DATACOLLECT_GET_SUMS(i, N_IGNORED, *start, end, overhead, sum, sum2);
+        DO_REAL_SIGNAL(consume);
+    }
+
+    *out_sum = sum;
+    *out_sum2 = sum2;
+    *out_num = N_RUNS - N_IGNORED;
 
     /* signal completion */
     seL4_Send(done_ep, seL4_MessageInfo_new(0, 0, 0, 0));
@@ -260,6 +292,47 @@ static void benchmark_prio_threads(env_t *env, seL4_CPtr ep, seL4_CPtr produce, 
     seL4_TCB_Suspend(low.tcb.cptr);
 }
 
+static void benchmark_prio_threads_ep(env_t *env, seL4_CPtr ep, seL4_CPtr produce, seL4_CPtr consume, scheduler_results_t *results)
+{
+    sel4utils_thread_t high, low;
+    char high_args_strings[N_HIGH_ARGS][WORD_STRING_SIZE];
+    char *high_argv[N_HIGH_ARGS];
+    char low_args_strings[N_LOW_ARGS][WORD_STRING_SIZE];
+    char *low_argv[N_LOW_ARGS];
+    ccnt_t start;
+    UNUSED int error;
+
+    benchmark_configure_thread(env, ep, seL4_MinPrio, "high", &high);
+    benchmark_configure_thread(env, ep, seL4_MinPrio, "low", &low);
+
+    sel4utils_create_word_args(high_args_strings, high_argv, N_HIGH_ARGS, produce,
+                               ep, (seL4_Word) &start, consume);
+
+    for (int i = 0; i < N_PRIOS; i++) {
+        uint8_t prio = gen_next_prio(i);
+        error = seL4_TCB_SetPriority(high.tcb.cptr, simple_get_tcb(&env->simple), prio);
+        assert(error == seL4_NoError);
+
+        sel4utils_create_word_args(low_args_strings, low_argv, N_LOW_ARGS, produce,
+                                   (seL4_Word) &start,
+                                   (seL4_Word) results->overhead_ccnt_min,
+                                   (seL4_Word) &results->thread_results_ep_sum[i],
+                                   (seL4_Word) &results->thread_results_ep_sum2[i],
+                                   (seL4_Word) &results->thread_results_ep_num[i],
+                                   ep, consume);
+
+        error = sel4utils_start_thread(&low, (sel4utils_thread_entry_fn) low_fn_ep, (void *) N_LOW_ARGS, (void *) low_argv, 1);
+        assert(error == seL4_NoError);
+        error = sel4utils_start_thread(&high, (sel4utils_thread_entry_fn) high_fn, (void *) N_HIGH_ARGS, (void *) high_argv, 1);
+        assert(error == seL4_NoError);
+
+        benchmark_wait_children(ep, "children of scheduler benchmark", 2);
+    }
+
+    seL4_TCB_Suspend(high.tcb.cptr);
+    seL4_TCB_Suspend(low.tcb.cptr);
+}
+
 static void benchmark_prio_processes(env_t *env, seL4_CPtr ep, seL4_CPtr produce, seL4_CPtr consume,
                                      ccnt_t results[N_PRIOS][N_RUNS])
 {
@@ -313,6 +386,75 @@ static void benchmark_prio_processes(env_t *env, seL4_CPtr ep, seL4_CPtr produce
                                    (seL4_Word) start, (seL4_Word) &results[i], ep, consume);
 
         error = sel4utils_start_thread(&low, (sel4utils_thread_entry_fn) low_fn, (void *) N_LOW_ARGS, (void *) low_argv, 1);
+        assert(error == seL4_NoError);
+
+        error = benchmark_spawn_process(&high, &env->slab_vka, &env->vspace, N_HIGH_ARGS, high_argv, 1);
+        assert(error == seL4_NoError);
+
+        benchmark_wait_children(ep, "children of scheduler benchmark", 2);
+    }
+
+    seL4_TCB_Suspend(high.thread.tcb.cptr);
+    seL4_TCB_Suspend(low.tcb.cptr);
+}
+
+static void benchmark_prio_processes_ep(env_t *env, seL4_CPtr ep, seL4_CPtr produce, seL4_CPtr consume, scheduler_results_t *results)
+{
+    sel4utils_process_t high;
+    sel4utils_thread_t low;
+    char high_args_strings[N_HIGH_ARGS][WORD_STRING_SIZE];
+    char *high_argv[N_HIGH_ARGS];
+    char low_args_strings[N_LOW_ARGS][WORD_STRING_SIZE];
+    char *low_argv[N_LOW_ARGS];
+    void *start, *remote_start;
+    seL4_CPtr remote_ep, remote_produce, remote_consume;
+    UNUSED int error;
+    cspacepath_t path;
+
+    /* allocate a page to share for the start cycle count */
+    start = vspace_new_pages(&env->vspace, seL4_AllRights, 1, seL4_PageBits);
+    assert(start != NULL);
+
+    benchmark_shallow_clone_process(env, &high, seL4_MinPrio, high_fn, "high");
+    /* run low in the same thread as us so we don't have to copy the results across */
+    benchmark_configure_thread(env, ep, seL4_MinPrio, "low", &low);
+
+    /* share memory for shared variable */
+    remote_start = vspace_share_mem(&env->vspace, &high.vspace, start, 1, seL4_PageBits, seL4_AllRights, 1);
+    assert(remote_start != NULL);
+
+    /* copy ep cap */
+    vka_cspace_make_path(&env->slab_vka, ep, &path);
+    remote_ep = sel4utils_copy_path_to_process(&high, path);
+    assert(remote_ep != seL4_CapNull);
+
+    /* copy ntfn cap */
+    vka_cspace_make_path(&env->slab_vka, produce, &path);
+    remote_produce = sel4utils_copy_path_to_process(&high, path);
+    assert(remote_produce != seL4_CapNull);
+
+    /* copy ntfn cap */
+    vka_cspace_make_path(&env->slab_vka, consume, &path);
+    remote_consume = sel4utils_copy_path_to_process(&high, path);
+    assert(remote_consume != seL4_CapNull);
+
+    sel4utils_create_word_args(high_args_strings, high_argv, N_HIGH_ARGS, remote_produce,
+                               remote_ep, (seL4_Word) remote_start, remote_consume);
+
+    for (int i = 0; i < N_PRIOS; i++) {
+        uint8_t prio = gen_next_prio(i);
+        error = seL4_TCB_SetPriority(high.thread.tcb.cptr, simple_get_tcb(&env->simple), prio);
+        assert(error == 0);
+
+        sel4utils_create_word_args(low_args_strings, low_argv, N_LOW_ARGS, produce,
+                                   (seL4_Word) start,
+                                   (seL4_Word) results->overhead_ccnt_min,
+                                   (seL4_Word) &results->process_results_ep_sum[i],
+                                   (seL4_Word) &results->process_results_ep_sum2[i],
+                                   (seL4_Word) &results->process_results_ep_num[i],
+                                   ep, consume);
+
+        error = sel4utils_start_thread(&low, (sel4utils_thread_entry_fn) low_fn_ep, (void *) N_LOW_ARGS, (void *) low_argv, 1);
         assert(error == seL4_NoError);
 
         error = benchmark_spawn_process(&high, &env->slab_vka, &env->vspace, N_HIGH_ARGS, high_argv, 1);
@@ -432,8 +574,10 @@ int main(int argc, char **argv)
 
     benchmark_prio_threads(env, done_ep.cptr, produce.cptr, consume.cptr,
                            results->thread_results);
+    benchmark_prio_threads_ep(env, done_ep.cptr, produce.cptr, consume.cptr, results);
     benchmark_prio_processes(env, done_ep.cptr, produce.cptr, consume.cptr,
                              results->process_results);
+    benchmark_prio_processes_ep(env, done_ep.cptr, produce.cptr, consume.cptr, results);
     benchmark_set_prio_average(results->set_prio_average, simple_get_tcb(&env->simple));
 
     /* thread yield benchmarks */

--- a/apps/scheduler/src/main.c
+++ b/apps/scheduler/src/main.c
@@ -292,7 +292,8 @@ static void benchmark_prio_threads(env_t *env, seL4_CPtr ep, seL4_CPtr produce, 
     seL4_TCB_Suspend(low.tcb.cptr);
 }
 
-static void benchmark_prio_threads_ep(env_t *env, seL4_CPtr ep, seL4_CPtr produce, seL4_CPtr consume, scheduler_results_t *results)
+static void benchmark_prio_threads_ep(env_t *env, seL4_CPtr ep, seL4_CPtr produce, seL4_CPtr consume,
+                                      scheduler_results_t *results)
 {
     sel4utils_thread_t high, low;
     char high_args_strings[N_HIGH_ARGS][WORD_STRING_SIZE];
@@ -398,7 +399,8 @@ static void benchmark_prio_processes(env_t *env, seL4_CPtr ep, seL4_CPtr produce
     seL4_TCB_Suspend(low.tcb.cptr);
 }
 
-static void benchmark_prio_processes_ep(env_t *env, seL4_CPtr ep, seL4_CPtr produce, seL4_CPtr consume, scheduler_results_t *results)
+static void benchmark_prio_processes_ep(env_t *env, seL4_CPtr ep, seL4_CPtr produce, seL4_CPtr consume,
+                                        scheduler_results_t *results)
 {
     sel4utils_process_t high;
     sel4utils_thread_t low;

--- a/apps/sel4bench/src/fault.c
+++ b/apps/sel4bench/src/fault.c
@@ -42,7 +42,7 @@ static json_t *fault_process(void *results)
 
     set.name = "fault round trip (early processing)";
     result = process_result_early_proc(raw_results->round_trip_ep_num, raw_results->round_trip_ep_sum,
-                                       raw_results->round_trip_ep_sum2, raw_results->round_trip_ep);
+                                       raw_results->round_trip_ep_sum2);
     json_array_append_new(array, result_set_to_json(set));
 
     set.name = "faulter -> fault handler";
@@ -51,7 +51,7 @@ static json_t *fault_process(void *results)
 
     set.name = "faulter -> fault handler (early processing)";
     result = process_result_early_proc(raw_results->fault_ep_num, raw_results->fault_ep_sum,
-                                       raw_results->fault_ep_sum2, raw_results->fault_ep);
+                                       raw_results->fault_ep_sum2);
     json_array_append_new(array, result_set_to_json(set));
 
     /* calculate the overhead of reading the cycle count (fault handler -> faulter path
@@ -73,7 +73,7 @@ static json_t *fault_process(void *results)
     /* fault to fault handler does not */
     set.name = "fault handler -> faulter (early processing)";
     result = process_result_early_proc(raw_results->fault_reply_ep_num, raw_results->fault_reply_ep_sum,
-                                       raw_results->fault_reply_ep_sum2, raw_results->fault_reply_ep);
+                                       raw_results->fault_reply_ep_sum2);
     json_array_append_new(array, result_set_to_json(set));
 
     return array;

--- a/apps/sel4bench/src/hardware.c
+++ b/apps/sel4bench/src/hardware.c
@@ -39,7 +39,7 @@ static json_t *hardware_process(void *results)
 
     set.name = "Hardware null_syscall thread (early processing)";
     result = process_result_early_proc(raw_results->nullSyscall_ep_num, raw_results->nullSyscall_ep_sum,
-                                       raw_results->nullSyscall_ep_sum2, raw_results->nullSyscall_ep);
+                                       raw_results->nullSyscall_ep_sum2);
     json_array_append_new(array, result_set_to_json(set));
 
     set.name = "Nop syscall overhead";

--- a/apps/sel4bench/src/irq.c
+++ b/apps/sel4bench/src/irq.c
@@ -32,13 +32,11 @@ static json_t *irquser_process(void *r)
     results[1] = process_result(N_RUNS, raw_results->thread_results, desc);
     results[2] = process_result_early_proc(raw_results->thread_results_ep_num,
                                            raw_results->thread_results_ep_sum,
-                                           raw_results->thread_results_ep_sum2,
-                                           raw_results->thread_results_ep);
+                                           raw_results->thread_results_ep_sum2);
     results[3] = process_result(N_RUNS, raw_results->process_results, desc);
     results[4] = process_result_early_proc(raw_results->process_results_ep_num,
                                            raw_results->process_results_ep_sum,
-                                           raw_results->process_results_ep_sum2,
-                                           raw_results->process_results_ep);
+                                           raw_results->process_results_ep_sum2);
 
     char *types[] = {"Measurement overhead", "Without context switch",
                      "Without context switch (early processing)", "With context switch",

--- a/apps/sel4bench/src/json.c
+++ b/apps/sel4bench/src/json.c
@@ -52,7 +52,7 @@ static void result_to_json(result_t result, json_t *j)
     json_t *raw_results = json_array();
     assert(raw_results != NULL);
 
-    if (config_set(CONFIG_OUTPUT_RAW_RESULTS)) {
+    if (config_set(CONFIG_OUTPUT_RAW_RESULTS) && result.raw_data != NULL) {
         for (size_t i = 0; i < result.samples; i++) {
             error = json_array_append_new(raw_results, json_integer(result.raw_data[i]));
             assert(error == 0);

--- a/apps/sel4bench/src/json.c
+++ b/apps/sel4bench/src/json.c
@@ -8,6 +8,11 @@
 #include <math.h>
 #include "json.h"
 
+static inline double round_to_3_decimal_places(double val)
+{
+    return nearbyint(val * 1000.0) / 1000.0;
+}
+
 static inline json_t *json_real_check(double val)
 {
     json_t *real = json_real(val);
@@ -28,7 +33,7 @@ static void result_to_json(result_t result, json_t *j)
     error = json_object_set_new(j, "Mean", json_real_check(result.mean));
     assert(error == 0);
 
-    error = json_object_set_new(j, "Stddev", json_real_check(result.stddev));
+    error = json_object_set_new(j, "Stddev", json_real_check(round_to_3_decimal_places(result.stddev)));
     assert(error == 0);
 
     error = json_object_set_new(j, "Variance", json_real_check(result.variance));

--- a/apps/sel4bench/src/main.c
+++ b/apps/sel4bench/src/main.c
@@ -297,7 +297,7 @@ void *main_continued(void *arg)
     }
 
     printf("JSON OUTPUT\n");
-    error = json_dumpf(output, stdout, JSON_PRESERVE_ORDER | JSON_INDENT(CONFIG_JSON_INDENT));
+    error = json_dumpf(output, stdout, JSON_PRESERVE_ORDER | JSON_INDENT(CONFIG_JSON_INDENT) | JSON_REAL_PRECISION(16));
     ZF_LOGF_IF(error, "Failed to dump output");
 
     printf("END JSON OUTPUT\n");

--- a/apps/sel4bench/src/math.c
+++ b/apps/sel4bench/src/math.c
@@ -168,18 +168,15 @@ static double results_variance_early_proc(const size_t num, const ccnt_t sum,
     return variance;
 }
 
-result_t calculate_results_early_proc(ccnt_t num, ccnt_t sum, ccnt_t sum2, ccnt_t array[num])
+result_t calculate_results_early_proc(ccnt_t num, ccnt_t sum, ccnt_t sum2)
 {
-
     result_t result;
 
     memset((void *)&result, 0, sizeof(result));
     result.mean = sum / num;
     result.variance = results_variance_early_proc(num, sum, sum2, result.mean);
     result.stddev = sqrt(result.variance * ((double) num / (double)(num - 1.0f)));;
-    result.raw_data = array;
     result.samples = num;
 
     return result;
-
 }

--- a/apps/sel4bench/src/math.c
+++ b/apps/sel4bench/src/math.c
@@ -23,7 +23,7 @@ static double results_mean(const size_t n, const ccnt_t array[n])
     for (i = 0; i < n; i++) {
         mean += (array[i] - mean) / (i + 1);
     }
-    return mean;
+    return roundl(mean);
 }
 
 static double results_variance(const size_t n, const ccnt_t array[n], const ccnt_t mean)
@@ -38,7 +38,7 @@ static double results_variance(const size_t n, const ccnt_t array[n], const ccnt
         variance += (delta * delta - variance) / (i + 1);
     }
 
-    return (double) variance;
+    return round((double) variance);
 }
 
 static double results_stddev(const size_t n, const ccnt_t array[n], const long double variance)

--- a/apps/sel4bench/src/math.h
+++ b/apps/sel4bench/src/math.h
@@ -16,11 +16,8 @@ result_t calculate_results(const size_t n, ccnt_t data[n]);
  * @param num - number of samples
  * @param sum - sum of samples
  * @param sum2 - sum of squared samples
- * @param array - array of raw data which are zeros for Early Processing methodology
- * but the array is required for results output function
  */
-result_t calculate_results_early_proc(ccnt_t num, ccnt_t sum, ccnt_t sum2,
-                                      ccnt_t array[num]);
+result_t calculate_results_early_proc(ccnt_t num, ccnt_t sum, ccnt_t sum2);
 
 /* The function calculates variance using sum, sum of squared values and mean
  * @param num - number of samples

--- a/apps/sel4bench/src/processing.c
+++ b/apps/sel4bench/src/processing.c
@@ -75,3 +75,10 @@ void process_results(size_t ncols, size_t nrows, ccnt_t array[ncols][nrows], res
         results[i] = process_result(nrows, array[i], desc);
     }
 }
+
+void process_results_early_proc(ccnt_t ncols, ccnt_t nums[ncols], ccnt_t sums[ncols], ccnt_t sum2s[ncols], result_t results[ncols])
+{
+    for (int i = 0; i < ncols; i++) {
+        results[i] = process_result_early_proc(nums[i], sums[i], sum2s[i], NULL);
+    }
+}

--- a/apps/sel4bench/src/processing.c
+++ b/apps/sel4bench/src/processing.c
@@ -63,9 +63,9 @@ result_t process_result(size_t n, ccnt_t array[n], result_desc_t desc)
     return calculate_results(size, array);
 }
 
-result_t process_result_early_proc(ccnt_t num, ccnt_t sum, ccnt_t sum2, ccnt_t array[num])
+result_t process_result_early_proc(ccnt_t num, ccnt_t sum, ccnt_t sum2)
 {
-    return calculate_results_early_proc(num, sum, sum2, array);
+    return calculate_results_early_proc(num, sum, sum2);
 }
 
 void process_results(size_t ncols, size_t nrows, ccnt_t array[ncols][nrows], result_desc_t desc,
@@ -79,6 +79,6 @@ void process_results(size_t ncols, size_t nrows, ccnt_t array[ncols][nrows], res
 void process_results_early_proc(ccnt_t ncols, ccnt_t nums[ncols], ccnt_t sums[ncols], ccnt_t sum2s[ncols], result_t results[ncols])
 {
     for (int i = 0; i < ncols; i++) {
-        results[i] = process_result_early_proc(nums[i], sums[i], sum2s[i], NULL);
+        results[i] = process_result_early_proc(nums[i], sums[i], sum2s[i]);
     }
 }

--- a/apps/sel4bench/src/processing.c
+++ b/apps/sel4bench/src/processing.c
@@ -76,7 +76,8 @@ void process_results(size_t ncols, size_t nrows, ccnt_t array[ncols][nrows], res
     }
 }
 
-void process_results_early_proc(ccnt_t ncols, ccnt_t nums[ncols], ccnt_t sums[ncols], ccnt_t sum2s[ncols], result_t results[ncols])
+void process_results_early_proc(ccnt_t ncols, ccnt_t nums[ncols], ccnt_t sums[ncols], ccnt_t sum2s[ncols],
+                                result_t results[ncols])
 {
     for (int i = 0; i < ncols; i++) {
         results[i] = process_result_early_proc(nums[i], sums[i], sum2s[i]);

--- a/apps/sel4bench/src/processing.h
+++ b/apps/sel4bench/src/processing.h
@@ -52,3 +52,5 @@ void process_results(size_t ncols, size_t nrows, ccnt_t array[ncols][nrows], res
  * @param results destination of the result of this function
  */
 void process_average_results(int rows, int cols, ccnt_t array[rows][cols], result_t results[cols]);
+
+void process_results_early_proc(ccnt_t ncols, ccnt_t nums[ncols], ccnt_t sums[ncols], ccnt_t sum2s[ncols], result_t results[ncols]);

--- a/apps/sel4bench/src/processing.h
+++ b/apps/sel4bench/src/processing.h
@@ -22,10 +22,8 @@ result_t process_result(size_t n, ccnt_t array[n], result_desc_t desc);
  * @param num   number of values to process
  * @param sum   sum of values
  * @param sum2  sum of squared values
- * @param array raw values to compute results for
  */
-result_t process_result_early_proc(ccnt_t num, ccnt_t sum, ccnt_t sum2,
-                                   ccnt_t array[num]);
+result_t process_result_early_proc(ccnt_t num, ccnt_t sum, ccnt_t sum2);
 
 /**
  * @param ncols    size of the 1st dimension of array.
@@ -53,4 +51,13 @@ void process_results(size_t ncols, size_t nrows, ccnt_t array[ncols][nrows], res
  */
 void process_average_results(int rows, int cols, ccnt_t array[rows][cols], result_t results[cols]);
 
-void process_results_early_proc(ccnt_t ncols, ccnt_t nums[ncols], ccnt_t sums[ncols], ccnt_t sum2s[ncols], result_t results[ncols]);
+/* Process a set of early processing results. Compute the variance, standard deviation, mean for each set of values
+ * for benchmarks using Early Processing methodology
+ * @param ncols   number of values in each array
+ * @param nums    array of number of samples in each run
+ * @param sums    array of sum of values
+ * @param sum2s   array of sum of squared values
+ * @param results array of results to fill in
+ */
+void process_results_early_proc(ccnt_t ncols, ccnt_t nums[ncols], ccnt_t sums[ncols], ccnt_t sum2s[ncols],
+                                result_t results[ncols]);

--- a/apps/sel4bench/src/scheduler.c
+++ b/apps/sel4bench/src/scheduler.c
@@ -93,8 +93,23 @@ static void process_scheduler_results(scheduler_results_t *results, json_t *arra
     set.n_results = N_PRIOS,
     json_array_append_new(array, result_set_to_json(set));
 
+    /* signal to thread of higher prio (early processing) */
+    result_t per_prio_result_ep[N_PRIOS];
+    process_results_early_proc(N_PRIOS, results->thread_results_ep_num, results->thread_results_ep_sum, results->thread_results_ep_sum2, per_prio_result_ep);
+
+    set.name = "Signal to thread of higher prio (early processing)";
+    set.results = per_prio_result_ep;
+    json_array_append_new(array, result_set_to_json(set));
+
     set.name = "Signal to process of higher prio";
     process_results(N_PRIOS, N_RUNS, results->process_results, desc, per_prio_result);
+    json_array_append_new(array, result_set_to_json(set));
+
+    /* signal to process of higher prio (early processing) */
+    process_results_early_proc(N_PRIOS, results->process_results_ep_num, results->process_results_ep_sum, results->process_results_ep_sum2, per_prio_result_ep);
+
+    set.name = "Signal to process of higher prio (early processing)";
+    set.results = per_prio_result_ep;
     json_array_append_new(array, result_set_to_json(set));
 
     result_t average_results[NUM_AVERAGE_EVENTS];

--- a/apps/sel4bench/src/scheduler.c
+++ b/apps/sel4bench/src/scheduler.c
@@ -30,7 +30,7 @@ static void process_yield_results(scheduler_results_t *results, ccnt_t overhead,
 
     set.name = "Thread yield (early processing)";
     result = process_result_early_proc(results->thread_yield_ep_num, results->thread_yield_ep_sum,
-                                       results->thread_yield_ep_sum2, results->thread_yield_ep);
+                                       results->thread_yield_ep_sum2);
     json_array_append_new(array, result_set_to_json(set));
 
     set.name = "Process yield";
@@ -39,7 +39,7 @@ static void process_yield_results(scheduler_results_t *results, ccnt_t overhead,
 
     set.name = "Process yield (early processing)";
     result = process_result_early_proc(results->process_yield_ep_num, results->process_yield_ep_sum,
-                                       results->process_yield_ep_sum2, results->process_yield_ep);
+                                       results->process_yield_ep_sum2);
     json_array_append_new(array, result_set_to_json(set));
 
     result_t average_results[NUM_AVERAGE_EVENTS];

--- a/apps/sel4bench/src/scheduler.c
+++ b/apps/sel4bench/src/scheduler.c
@@ -95,7 +95,8 @@ static void process_scheduler_results(scheduler_results_t *results, json_t *arra
 
     /* signal to thread of higher prio (early processing) */
     result_t per_prio_result_ep[N_PRIOS];
-    process_results_early_proc(N_PRIOS, results->thread_results_ep_num, results->thread_results_ep_sum, results->thread_results_ep_sum2, per_prio_result_ep);
+    process_results_early_proc(N_PRIOS, results->thread_results_ep_num, results->thread_results_ep_sum,
+                               results->thread_results_ep_sum2, per_prio_result_ep);
 
     set.name = "Signal to thread of higher prio (early processing)";
     set.results = per_prio_result_ep;
@@ -106,7 +107,8 @@ static void process_scheduler_results(scheduler_results_t *results, json_t *arra
     json_array_append_new(array, result_set_to_json(set));
 
     /* signal to process of higher prio (early processing) */
-    process_results_early_proc(N_PRIOS, results->process_results_ep_num, results->process_results_ep_sum, results->process_results_ep_sum2, per_prio_result_ep);
+    process_results_early_proc(N_PRIOS, results->process_results_ep_num, results->process_results_ep_sum,
+                               results->process_results_ep_sum2, per_prio_result_ep);
 
     set.name = "Signal to process of higher prio (early processing)";
     set.results = per_prio_result_ep;

--- a/apps/sel4bench/src/signal.c
+++ b/apps/sel4bench/src/signal.c
@@ -36,8 +36,7 @@ static json_t *signal_process(void *results)
     desc.overhead = result.min;
 
     result = process_result_early_proc(raw_results->lo_num,
-                                       raw_results->lo_sum, raw_results->lo_sum2,
-                                       raw_results->diag_results);
+                                       raw_results->lo_sum, raw_results->lo_sum2);
 
     set.name = "Signal to high prio thread (early processing)";
     json_array_append_new(array, result_set_to_json(set));

--- a/apps/sel4bench/src/sync.c
+++ b/apps/sel4bench/src/sync.c
@@ -76,15 +76,13 @@ static json_t *sync_process(void *results)
 
     result = process_result_early_proc(raw_results->producer_to_consumer_ep_num,
                                        raw_results->producer_to_consumer_ep_sum,
-                                       raw_results->producer_to_consumer_ep_sum2,
-                                       raw_results->producer_to_consumer_ep);
+                                       raw_results->producer_to_consumer_ep_sum2);
     set.name = "Producer to consumer (early processing)";
     json_array_append_new(array, result_set_to_json(set));
 
     result = process_result_early_proc(raw_results->consumer_to_producer_ep_num,
                                        raw_results->consumer_to_producer_ep_sum,
-                                       raw_results->consumer_to_producer_ep_sum2,
-                                       raw_results->consumer_to_producer_ep);
+                                       raw_results->consumer_to_producer_ep_sum2);
     set.name = "Consumer to producer (early processing)";
     json_array_append_new(array, result_set_to_json(set));
 

--- a/libsel4benchsupport/include/fault.h
+++ b/libsel4benchsupport/include/fault.h
@@ -27,17 +27,14 @@ typedef struct {
     ccnt_t round_trip_ep_sum2;
     ccnt_t round_trip_ep_num;
     ccnt_t round_trip_ep_min_overhead;
-    ccnt_t round_trip_ep[N_RUNS];
 
     ccnt_t fault_ep_sum;
     ccnt_t fault_ep_sum2;
     ccnt_t fault_ep_num;
     ccnt_t fault_ep_min_overhead;
-    ccnt_t fault_ep[N_RUNS];
 
     ccnt_t fault_reply_ep_sum;
     ccnt_t fault_reply_ep_sum2;
     ccnt_t fault_reply_ep_num;
     ccnt_t fault_reply_ep_min_overhead;
-    ccnt_t fault_reply_ep[N_RUNS];
 } fault_results_t;

--- a/libsel4benchsupport/include/hardware.h
+++ b/libsel4benchsupport/include/hardware.h
@@ -20,5 +20,4 @@ typedef struct hardware_results {
     ccnt_t nullSyscall_ep_sum;
     ccnt_t nullSyscall_ep_sum2;
     ccnt_t nullSyscall_ep_num;
-    ccnt_t nullSyscall_ep[N_RUNS];
 } hardware_results_t;

--- a/libsel4benchsupport/include/irq.h
+++ b/libsel4benchsupport/include/irq.h
@@ -24,10 +24,8 @@ typedef struct irquser_results_t {
     ccnt_t thread_results_ep_sum;
     ccnt_t thread_results_ep_sum2;
     ccnt_t thread_results_ep_num;
-    ccnt_t thread_results_ep[N_RUNS];
 
     ccnt_t process_results_ep_sum;
     ccnt_t process_results_ep_sum2;
     ccnt_t process_results_ep_num;
-    ccnt_t process_results_ep[N_RUNS];
 } irquser_results_t;

--- a/libsel4benchsupport/include/scheduler.h
+++ b/libsel4benchsupport/include/scheduler.h
@@ -29,7 +29,6 @@ typedef struct scheduler_results_t {
     ccnt_t thread_yield_ep_sum;
     ccnt_t thread_yield_ep_sum2;
     ccnt_t thread_yield_ep_num;
-    ccnt_t thread_yield_ep[N_RUNS];
 
     ccnt_t thread_results_ep_sum[N_PRIOS];
     ccnt_t thread_results_ep_sum2[N_PRIOS];
@@ -38,12 +37,10 @@ typedef struct scheduler_results_t {
     ccnt_t process_yield_ep_sum;
     ccnt_t process_yield_ep_sum2;
     ccnt_t process_yield_ep_num;
-    ccnt_t process_yield_ep[N_RUNS];
 
     ccnt_t process_results_ep_sum[N_PRIOS];
     ccnt_t process_results_ep_sum2[N_PRIOS];
     ccnt_t process_results_ep_num[N_PRIOS];
-
 } scheduler_results_t;
 
 static inline uint8_t gen_next_prio(int i)

--- a/libsel4benchsupport/include/scheduler.h
+++ b/libsel4benchsupport/include/scheduler.h
@@ -31,10 +31,19 @@ typedef struct scheduler_results_t {
     ccnt_t thread_yield_ep_num;
     ccnt_t thread_yield_ep[N_RUNS];
 
+    ccnt_t thread_results_ep_sum[N_PRIOS];
+    ccnt_t thread_results_ep_sum2[N_PRIOS];
+    ccnt_t thread_results_ep_num[N_PRIOS];
+
     ccnt_t process_yield_ep_sum;
     ccnt_t process_yield_ep_sum2;
     ccnt_t process_yield_ep_num;
     ccnt_t process_yield_ep[N_RUNS];
+
+    ccnt_t process_results_ep_sum[N_PRIOS];
+    ccnt_t process_results_ep_sum2[N_PRIOS];
+    ccnt_t process_results_ep_num[N_PRIOS];
+
 } scheduler_results_t;
 
 static inline uint8_t gen_next_prio(int i)

--- a/libsel4benchsupport/include/sync.h
+++ b/libsel4benchsupport/include/sync.h
@@ -49,12 +49,10 @@ typedef struct sync_results {
     ccnt_t producer_to_consumer_ep_sum;
     ccnt_t producer_to_consumer_ep_sum2;
     ccnt_t producer_to_consumer_ep_num;
-    ccnt_t producer_to_consumer_ep[N_RUNS];
 
     ccnt_t consumer_to_producer_ep_sum;
     ccnt_t consumer_to_producer_ep_sum2;
     ccnt_t consumer_to_producer_ep_num;
-    ccnt_t consumer_to_producer_ep[N_RUNS];
 } sync_results_t;
 
 typedef void (*helper_func_t)(int argc, char *argv[]);


### PR DESCRIPTION
This PR adds missing early processing for two benchmarks:
- Signal to thread of higher prio (early processing)
- Signal to process of higher prio (early processing)

It also:
- removes saving of the redundant empty array of samples and storing them in the test structures
- rounds mean/variance results output to the JSON file
- rounds stddev to 3 decimal places