### PR TITLE
libsel4benchsupport: general_regs_only

### DIFF
--- a/libsel4benchsupport/CMakeLists.txt
+++ b/libsel4benchsupport/CMakeLists.txt
@@ -27,3 +27,5 @@ target_link_libraries(
     sel4rpc
     sel4serialserver
 )
+
+general_regs_only(sel4benchsupport)

--- a/libsel4benchsupport/CMakeLists.txt
+++ b/libsel4benchsupport/CMakeLists.txt
@@ -12,20 +12,17 @@ file(GLOB deps src/*.c src/arch/${KernelArch}/*.c)
 list(SORT deps)
 
 add_library(sel4benchsupport EXCLUDE_FROM_ALL ${deps})
-target_include_directories(
-    sel4benchsupport PUBLIC "include/" "arch_include/${KernelArch}/"
-                            "sel4_arch_include/${KernelSel4Arch}/"
-)
+target_include_directories(sel4benchsupport PUBLIC "include/" "arch_include/${KernelArch}/"
+                                                   "sel4_arch_include/${KernelSel4Arch}/")
 target_link_libraries(
-    sel4benchsupport
-    sel4_autoconf
-    muslc
-    sel4runtime
-    sel4allocman
-    sel4bench
-    sel4muslcsys
-    sel4rpc
-    sel4serialserver
-)
+  sel4benchsupport
+  sel4_autoconf
+  muslc
+  sel4runtime
+  sel4allocman
+  sel4bench
+  sel4muslcsys
+  sel4rpc
+  sel4serialserver)
 
 general_regs_only(sel4benchsupport)


### PR DESCRIPTION
Compile libsel4benchsupport with general_regs_only to avoid faults on SIMD instructions in benchmarks where FPU is off.

I don't know if this is too big a hammer. @Indanz what is your opinion on that?

The failing run https://github.com/seL4/sel4bench/actions/runs/25541395179/job/74969378606#step:5:427 fails on a vector instruction in `irquser`, which is already compiled with `general_regs_only`. It seems that libsel4benchsupport is compiled separately and brings vector instructions back in. Forcing `general_regs_only` works, but it does now mean that all of `libsel4benchsupport` is with general registers only.

(I might be wrong but I think the vector instruction is actually emitted for a seL4 syscall stub -- so much for OS code not using them..)
