### PR TITLE
page_mapping: avoid vector optimisations

### DIFF
--- a/apps/page_mapping/CMakeLists.txt
+++ b/apps/page_mapping/CMakeLists.txt
@@ -47,3 +47,5 @@ target_link_libraries(
 if(AppPageMappingBench)
     set_property(GLOBAL APPEND PROPERTY sel4benchapps_property "$<TARGET_FILE:page_mapping>")
 endif()
+
+general_regs_only(page_mapping)

--- a/apps/page_mapping/CMakeLists.txt
+++ b/apps/page_mapping/CMakeLists.txt
@@ -10,42 +10,40 @@ project(page_mapping C)
 
 set(configure_string "")
 config_option(
-    AppPageMappingBench
-    APP_PAGEMAPPINGBENCH
-    "Application to benchmark seL4 mapping a series of pages."
-    DEFAULT
-    ON
-    DEPENDS
-    "DefaultBenchDeps"
-)
+  AppPageMappingBench
+  APP_PAGEMAPPINGBENCH
+  "Application to benchmark seL4 mapping a series of pages."
+  DEFAULT
+  ON
+  DEPENDS
+  "DefaultBenchDeps")
 add_config_library(sel4benchpagemapping "${configure_string}")
 
 file(GLOB deps src/*.c)
 list(SORT deps)
 add_executable(page_mapping EXCLUDE_FROM_ALL ${deps})
 target_link_libraries(
-    page_mapping
-    sel4_autoconf
-    sel4benchpagemapping_Config
-    sel4
-    muslc
-    cpio
-    sel4vka
-    sel4vspace
-    sel4allocman
-    sel4utils
-    sel4muslcsys
-    elf
-    sel4simple
-    sel4bench
-    sel4benchsupport
-    sel4debug
-    platsupport
-    sel4platsupport
-)
+  page_mapping
+  sel4_autoconf
+  sel4benchpagemapping_Config
+  sel4
+  muslc
+  cpio
+  sel4vka
+  sel4vspace
+  sel4allocman
+  sel4utils
+  sel4muslcsys
+  elf
+  sel4simple
+  sel4bench
+  sel4benchsupport
+  sel4debug
+  platsupport
+  sel4platsupport)
 
 if(AppPageMappingBench)
-    set_property(GLOBAL APPEND PROPERTY sel4benchapps_property "$<TARGET_FILE:page_mapping>")
+  set_property(GLOBAL APPEND PROPERTY sel4benchapps_property "$<TARGET_FILE:page_mapping>")
 endif()
 
 general_regs_only(page_mapping)


### PR DESCRIPTION
GCC 14.2 on x86 (32bit) with -O3 creates vector instructions that reference .rodata addresses, which are not included in the shallow clones sel4bench uses.

Add -fno-tree-vectorize to prevent these optimisations.

