### PR TITLE
workflows: use ${{ variable }} not invalid $${{

### DIFF
--- a/.github/workflows/sel4bench.yml
+++ b/.github/workflows/sel4bench.yml
@@ -96,7 +96,7 @@ jobs:
         with:
           platform: ${{ matrix.platform }}
           req: ${{ matrix.req }}
-          index: $${{ strategy.job-index }}
+          index: ${{ strategy.job-index }}
         env:
           HW_SSH: ${{ secrets.HW_SSH }}
       - name: Upload results


### PR DESCRIPTION
I'm not entirely sure how this worked... but I guess GitHub ignores the extra $ sign.