### PR TITLE
github: add result storage to deploy workflow

### DIFF
--- a/.github/workflows/sel4bench.yml
+++ b/.github/workflows/sel4bench.yml
@@ -124,36 +124,34 @@ jobs:
       uses: actions/checkout@v6
       with:
         repository: seL4/website
+        path: website
         token: ${{ secrets.PRIV_REPO_TOKEN }}
-    - name: Get results for web deployment (sabre)
+    - name: Check out results repo
+      uses: actions/checkout@v6
+      with:
+        repository: seL4/sel4bench-results
+        path: sel4bench-results
+        token: ${{ secrets.PRIV_REPO_TOKEN }}
+    - name: Get all result artifacts
       uses: actions/download-artifact@v8
       with:
-        name: sel4bench-results-sabre
-    - name: Get results for web deployment (haswell)
-      uses: actions/download-artifact@v8
-      with:
-        name: sel4bench-results-pc99-haswell3
-    - name: Get results for web deployment (skylake)
-      uses: actions/download-artifact@v8
-      with:
-        name: sel4bench-results-pc99-skylake
-    - name: Get results for web deployment (tx1)
-      uses: actions/download-artifact@v8
-      with:
-        name: sel4bench-results-tx1
-    - name: Get results for web deployment (hifive)
-      uses: actions/download-artifact@v8
-      with:
-        name: sel4bench-results-hifive
-    - name: Generate json results
+        pattern: sel4bench-results-*
+        path: results
+        merge-multiple: true
+    - name: Generate website json
       uses: seL4/ci-actions/sel4bench-web@master
       with:
         manifest_sha: ${{ steps.deploy.outputs.manifest_sha }}
     - name: Deploy to web site
       run: |
-        mv benchmarks.json _data/
+        cd website
+        mv ../benchmarks.json _data/
         git config user.name "seL4 CI"
         git config user.email "ci@sel4.systems"
         git add _data/benchmarks.json
         git commit -s -m "CI: update performance results"
         git push origin master
+    - name: Extract and deploy results to sel4bench-results
+      uses: seL4/ci-actions/sel4bench-metrics@master
+      with:
+        manifest_sha: ${{ steps.deploy.outputs.manifest_sha }}

--- a/.github/workflows/sel4bench.yml
+++ b/.github/workflows/sel4bench.yml
@@ -120,12 +120,6 @@ jobs:
         manifest_repo: sel4bench-manifest
       env:
         GH_SSH: ${{ secrets.CI_SSH }}
-    - name: Check out website repo
-      uses: actions/checkout@v6
-      with:
-        repository: seL4/website
-        path: website
-        token: ${{ secrets.PRIV_REPO_TOKEN }}
     - name: Check out results repo
       uses: actions/checkout@v6
       with:
@@ -138,6 +132,16 @@ jobs:
         pattern: sel4bench-results-*
         path: results
         merge-multiple: true
+    - name: Extract and deploy results to sel4bench-results
+      uses: seL4/ci-actions/sel4bench-metrics@master
+      with:
+        manifest_sha: ${{ steps.deploy.outputs.manifest_sha }}
+    - name: Check out website repo
+      uses: actions/checkout@v6
+      with:
+        repository: seL4/website
+        path: website
+        token: ${{ secrets.PRIV_REPO_TOKEN }}
     - name: Generate website json
       uses: seL4/ci-actions/sel4bench-web@master
       with:
@@ -151,7 +155,3 @@ jobs:
         git add _data/benchmarks.json
         git commit -s -m "CI: update performance results"
         git push origin master
-    - name: Extract and deploy results to sel4bench-results
-      uses: seL4/ci-actions/sel4bench-metrics@master
-      with:
-        manifest_sha: ${{ steps.deploy.outputs.manifest_sha }}


### PR DESCRIPTION
Add the sel4bench-metrics step to extract and store benchmark results in the sel4bench-results repo.

Adjust checkout path for website results for less messy top level.

Must be merged together with https://github.com/seL4/ci-actions/pull/496