### PR TITLE
page_mapping benchmark fixes

### DIFF
--- a/apps/page_mapping/src/main.c
+++ b/apps/page_mapping/src/main.c
@@ -192,6 +192,9 @@ bench_proc(int argc UNUSED, char *argv[])
     }
 
     sel4bench_destroy();
+
+    /* block to avoid running off call stack */
+    api_wait(result_ep, NULL);
 }
 
 static void run_bench_child_proc(env_t *env,

--- a/apps/page_mapping/src/main.c
+++ b/apps/page_mapping/src/main.c
@@ -258,8 +258,8 @@ int main(int argc, char *argv[])
     }
     vka_cspace_make_path(&env->slab_vka, result_ep.cptr, &result_ep_path);
 
-    /* allocate untyped cap for pages */
-    if ((vka_alloc_untyped(&env->delegate_vka, env->args->untyped_size_bits - 2,
+    /* allocate untyped cap for max n=2048 pages + potential page tables )*/
+    if ((vka_alloc_untyped(&env->delegate_vka, seL4_PageBits + 12,
                            &untyped_obj)) != 0) {
         ZF_LOGF("alloc untyped fail\n");
     };

--- a/apps/page_mapping/src/main.c
+++ b/apps/page_mapping/src/main.c
@@ -106,6 +106,7 @@ static void inline map_pages(seL4_CPtr addr, seL4_CPtr page_cap, int npage)
             err = seL4_ARCH_Page_Map(page_cap, SEL4UTILS_PD_SLOT, addr, right,\
                             seL4_ARCH_Default_VMAttributes);\
             assert(err == 0);\
+            addr += PAGE_SIZE_4K;\
             page_cap++;\
         }\
     }

--- a/apps/page_mapping/src/main.c
+++ b/apps/page_mapping/src/main.c
@@ -10,7 +10,14 @@
 #include <benchmark.h>
 #include <page_mapping.h>
 
+#if CONFIG_ARCH_AARCH64
+/* Pick START_ADDR below userTop, but high to avoid existing mapping in
+   top-level/2nd-level tables on AArch64. AArch64 Map does not return an error
+   for those, but maps deeper, which is harder to detect. */
+#define START_ADDR 0x8000000000
+#else
 #define START_ADDR 0x60000000
+#endif
 #define NUM_ARGS 3
 
 #define PAGE_PER_TABLE BIT(seL4_PageTableBits - seL4_WordSizeBits)
@@ -18,6 +25,39 @@
         seL4_Untyped_Retype(a,b,c,SEL4UTILS_CNODE_SLOT,\
                         SEL4UTILS_CNODE_SLOT,seL4_WordBits,e,1)
 #define NUM_PAGE_TABLE(npage) DIV_ROUND_UP((npage), PAGE_PER_TABLE)
+
+#ifdef CONFIG_ARCH_AARCH64
+#if defined(CONFIG_ARM_HYPERVISOR_SUPPORT) && defined(CONFIG_ARM_PA_SIZE_BITS_40)
+#define NUM_PT_LEVELS 3
+#else
+#define NUM_PT_LEVELS 4
+#endif
+/* counted from 0 from bottom, so L2 means third table from bottom, L1 means page directory */
+#define PT_L2_Map       seL4_ARM_PageTable_Map
+#define PT_L2_BITS      seL4_PageTableBits
+#define PT_L2_OBJ       seL4_ARM_PageTableObject
+#define PT_L1_Map       seL4_ARM_PageTable_Map
+#define PT_L1_BITS      seL4_PageTableBits
+#define PT_L1_OBJ       seL4_ARM_PageTableObject
+#elif CONFIG_ARCH_X86_64
+#define PT_L2_Map       seL4_X86_PDPT_Map
+#define PT_L2_OBJ       seL4_X86_PDPTObject
+#define PT_L2_BITS      seL4_PDPTBits
+#define PT_L1_Map       seL4_X86_PageDirectory_Map
+#define PT_L1_OBJ       seL4_X86_PageDirectoryObject
+#define PT_L1_BITS      seL4_PageDirBits
+#define NUM_PT_LEVELS 4
+#elif CONFIG_ARCH_RISCV
+#define PT_L2_Map       seL4_RISCV_PageTable_Map
+#define PT_L2_OBJ       seL4_RISCV_PageTableObject
+#define PT_L2_BITS      seL4_PageTableBits
+#define PT_L1_Map       seL4_RISCV_PageTable_Map
+#define PT_L1_OBJ       seL4_RISCV_PageTableObject
+#define PT_L1_BITS      seL4_PageTableBits
+#define NUM_PT_LEVELS   CONFIG_PT_LEVELS
+#else
+#define NUM_PT_LEVELS 2
+#endif
 
 typedef struct helper_thread {
     sel4utils_process_t process;
@@ -32,46 +72,46 @@ static void inline prepare_page_table(seL4_Word addr, int npage, seL4_CPtr untyp
                                       seL4_CPtr *free_slot)
 {
     long err UNUSED;
+    seL4_CPtr pt_cslot = *free_slot;
+
+    /* If there are > 2 PT levels, we need to map intermediate tables first */
+#if NUM_PT_LEVELS == 4
+    /* L2/L1 is counted from bottom so that level number is constant here */
+    err = untyped_retype_root(untyped, PT_L2_OBJ, PT_L2_BITS, pt_cslot);
+    assert(err == 0);
+
+    err = PT_L2_Map(pt_cslot, SEL4UTILS_PD_SLOT, addr, seL4_ARCH_Default_VMAttributes);
+    /* DeleteFirst happens if the second level from the top is already mapped
+       for this address. If the next level works, this is fine. */
+    assert(err == 0 || err == seL4_DeleteFirst);
+
+    pt_cslot++;
+#endif
+
+#if NUM_PT_LEVELS >= 3
+    err = untyped_retype_root(untyped, PT_L1_OBJ, PT_L1_BITS, pt_cslot);
+    assert(err == 0);
+
+    err = PT_L1_Map(pt_cslot, SEL4UTILS_PD_SLOT, addr, seL4_ARCH_Default_VMAttributes);
+    assert(err == 0);
+
+    pt_cslot++;
+#endif
+
     for (int i = 0; i < NUM_PAGE_TABLE(npage); i++) {
-        seL4_CPtr pt = *free_slot;
         err = untyped_retype_root(untyped, seL4_ARCH_PageTableObject,
-                                  seL4_PageTableBits, pt);
+                                  seL4_PageTableBits, pt_cslot);
         assert(err == 0);
-        (*free_slot)++;
 
-        err = seL4_ARCH_PageTable_Map(pt, SEL4UTILS_PD_SLOT, addr,
+        err = seL4_ARCH_PageTable_Map(pt_cslot, SEL4UTILS_PD_SLOT, addr,
                                       seL4_ARCH_Default_VMAttributes);
-
-#if defined(CONFIG_ARCH_X86_64)
-        if (err) {
-            seL4_CPtr pd = *free_slot;
-            err = untyped_retype_root(untyped, seL4_X86_PageDirectoryObject,
-                                      seL4_PageDirBits, pd);
-            assert(err == 0);
-            (*free_slot)++;
-            err = seL4_X86_PageDirectory_Map(pd, SEL4UTILS_PD_SLOT, addr,
-                                             seL4_ARCH_Default_VMAttributes);
-
-            if (err) {
-                seL4_CPtr pdpt = *free_slot;
-                err = untyped_retype_root(untyped, seL4_X86_PDPTObject,
-                                          seL4_PDPTBits, pdpt);
-                assert(err == 0);
-                (*free_slot)++;
-                err = seL4_X86_PDPT_Map(pdpt, SEL4UTILS_PD_SLOT, addr,
-                                        seL4_ARCH_Default_VMAttributes);
-                err = seL4_X86_PageDirectory_Map(pd, SEL4UTILS_PD_SLOT, addr,
-                                                 seL4_ARCH_Default_VMAttributes);
-            }
-
-            err = seL4_ARCH_PageTable_Map(pt, SEL4UTILS_PD_SLOT, addr,
-                                          seL4_ARCH_Default_VMAttributes);
-        }
-
-#endif /* CONFIG_ARCH_X86_64 */
         assert(err == 0);
+
+        pt_cslot++;
         addr += PAGE_SIZE_4K * PAGE_PER_TABLE;
     }
+
+    *free_slot = pt_cslot;
 }
 
 static void inline prepare_pages(int npage, seL4_CPtr untyped,
@@ -177,19 +217,6 @@ bench_proc(int argc UNUSED, char *argv[])
     SEL4BENCH_READ_CCNT(end);
     COMPILER_MEMORY_FENCE();
     send_result(result_ep, end - start);
-
-    /* cleaning */
-    long err;
-    for (int i = 0; i < npage; i++) {
-        err = seL4_ARCH_Page_Unmap(page_ptr_start + i);
-        ZF_LOGF_IFERR(err, "ummap page failed\n");
-    }
-
-    for (int i = 0; i < NUM_PAGE_TABLE(npage); i++) {
-        err = seL4_ARCH_PageTable_Unmap(pt_ptr_start + i);
-        ZF_LOGF_IFERR(err, "ummap page table failed\n");
-
-    }
 
     sel4bench_destroy();
 

--- a/apps/page_mapping/src/main.c
+++ b/apps/page_mapping/src/main.c
@@ -13,16 +13,10 @@
 #define START_ADDR 0x60000000
 #define NUM_ARGS 3
 
-#if defined(CONFIG_ARCH_X86_64)
-#define DEFAULT_DEPTH 64
-#else
-#define DEFAULT_DEPTH 32
-#endif /* defined(CONFIG_ARCH_X86_64) */
-
 #define PAGE_PER_TABLE BIT(seL4_PageTableBits - seL4_WordSizeBits)
 #define untyped_retype_root(a,b,c,e)\
         seL4_Untyped_Retype(a,b,c,SEL4UTILS_CNODE_SLOT,\
-                        SEL4UTILS_CNODE_SLOT,DEFAULT_DEPTH,e,1)
+                        SEL4UTILS_CNODE_SLOT,seL4_WordBits,e,1)
 #define NUM_PAGE_TABLE(npage) DIV_ROUND_UP((npage), PAGE_PER_TABLE)
 
 typedef struct helper_thread {

--- a/apps/sel4bench/src/page_mapping.c
+++ b/apps/sel4bench/src/page_mapping.c
@@ -24,7 +24,7 @@ static json_t *process_mapping_results(void *r)
     result_desc_t desc = {
         .stable = false,
         .name = "overhead",
-        .ignored = 0,
+        .ignored = 1,
         .overhead = 0
     };
     result_t overhead_result = process_result(RUNS,
@@ -71,6 +71,7 @@ static json_t *process_mapping_results(void *r)
             result_desc_t desc = {
                 .name = page_mapping_benchmark_params[i].name,
                 .overhead = overhead,
+                .ignored = 1,
             };
             results[i][j] =
                 process_result(RUNS, raw_results->benchmarks_result[i][j], desc);

--- a/libsel4benchsupport/include/page_mapping.h
+++ b/libsel4benchsupport/include/page_mapping.h
@@ -27,44 +27,8 @@ benchmark_params_t page_mapping_benchmark_params[] = {
         .npage  = 1,
     },
     {
-        .name   = "map 2",
-        .npage  = 2,
-    },
-    {
-        .name   = "map 4",
-        .npage  = 4,
-    },
-    {
-        .name   = "map 8",
-        .npage  = 8,
-    },
-    {
-        .name   = "map 16",
-        .npage  = 16,
-    },
-    {
-        .name   = "map 32",
-        .npage  = 32,
-    },
-    {
-        .name   = "map 64",
-        .npage  = 64,
-    },
-    {
-        .name   = "map 128",
-        .npage  = 128,
-    },
-    {
-        .name   = "map 256",
-        .npage  = 256,
-    },
-    {
         .name   = "map 512",
         .npage  = 512,
-    },
-    {
-        .name   = "map 1024",
-        .npage  = 1024,
     },
     {
         .name   = "map 2048",

--- a/libsel4benchsupport/include/page_mapping.h
+++ b/libsel4benchsupport/include/page_mapping.h
@@ -9,7 +9,7 @@
 #include <sel4bench/sel4bench.h>
 #include <sel4utils/process.h>
 
-#define RUNS 16
+#define RUNS 17
 #define TESTS ARRAY_SIZE(page_mapping_benchmark_params)
 #define NPHASE ARRAY_SIZE(phase_name)
 


### PR DESCRIPTION
This should fix most of the problems discussed in #73.

- make cnode depth arch independent
- fix missing addr increase for protect/unprotect
- use constant small untyped
- avoid running off stack (not a real problem, just convenient for debugging)
- add page table setup for missing architectures
- thin out number of different `npages` (see commit message for rationale)
- ignore first run for retype difference

I am least sure in this set about the page table setup. I took the basic idea from the capdl loader, but it's still not as clean as I'd had hoped. It's cleaner than it was before though, and does not have any unexpected failures in debug mode (tried x86, x64, aarch32, aarch64, rv64).

Overall I'm not sure this makes this benchmark super useful, but it is at least no obviously completely broken any more.