### PR TITLE
smp: reduce number of delay cycle data points

### DIFF
--- a/libsel4benchsupport/include/smp.h
+++ b/libsel4benchsupport/include/smp.h
@@ -25,11 +25,7 @@ typedef struct benchmark_params {
 static const
 benchmark_params_t smp_benchmark_params[] = {
     { .name = "500 cycles",   .delay = 500.000, },
-    { .name = "1000 cycles",  .delay = 1000.00, },
-    { .name = "2000 cycles",  .delay = 2000.00, },
     { .name = "4000 cycles",  .delay = 4000.00, },
-    { .name = "8000 cycles",  .delay = 8000.00, },
-    { .name = "16000 cycles", .delay = 16000.0, },
     { .name = "32000 cycles", .delay = 32000.0, },
 };
 


### PR DESCRIPTION
To reduce runtime, reduce the number of data points for different delay cycles.

The IPC cost behaviour is perfectly linear on the architectures where the delay works. Keeping one middle value should allow us to detect when that no longer is the case, and then we can increase data points again if we want to debug.

This test takes forever and the additional data points are pretty much useless. Looking at the numbers, it looks like the benchmark is broken for AArch64 (delay is not working), but I'm not fixing that now.
