### PR TITLE
page-mapping: consistent type for addr (trivial)

### DIFF
--- a/apps/page_mapping/src/main.c
+++ b/apps/page_mapping/src/main.c
@@ -127,7 +127,7 @@ static void inline prepare_pages(int npage, seL4_CPtr untyped,
     }
 }
 
-static void inline map_pages(seL4_CPtr addr, seL4_CPtr page_cap, int npage)
+static void inline map_pages(seL4_Word addr, seL4_CPtr page_cap, int npage)
 {
     long err UNUSED;
     for (int i = 0; i < npage; i++) {
@@ -140,7 +140,7 @@ static void inline map_pages(seL4_CPtr addr, seL4_CPtr page_cap, int npage)
 }
 
 #define PROT_UNPROT_NPAGE(func, right)\
-    static void inline func(seL4_CPtr addr, seL4_CPtr page_cap, int npage){\
+    static void inline func(seL4_Word addr, seL4_CPtr page_cap, int npage){\
         long err UNUSED;\
         for(int i = 0; i < npage; i++){\
             err = seL4_ARCH_Page_Map(page_cap, SEL4UTILS_PD_SLOT, addr, right,\


### PR DESCRIPTION
addr inconsistently used type seL4_CPtr in two places instead of seL4_Word. This is just for consistency (doesn't really change anything in the underlying C type).