### PR TITLE
smp: smaller sample window, more runs

### DIFF
--- a/apps/smp/src/main.c
+++ b/apps/smp/src/main.c
@@ -14,6 +14,8 @@
 
 #include "rnorrexp.h"
 
+#define SAMPLE_TIME (100 * NS_IN_MS)
+
 #define N_ARGS 5
 #define ZIGSEED 12345678
 
@@ -156,7 +158,8 @@ static inline ccnt_t benchmark_multicore_do_ping_pong(env_t *env, int nr_cores)
         total += (end[i] - start[i]);
     }
 
-    return total;
+    /* normalise throughput to ipc/sec, force 64 bit against mult overflow */
+    return ((uint64_t) total * NS_IN_S) / SAMPLE_TIME;
 }
 
 static void benchmark_multicore_ipc_throughput(env_t *env, smp_results_t *results)
@@ -243,7 +246,7 @@ int main(int argc, char *argv[])
     }
 
     ZF_LOGF_IF(ltimer_reset(&env->ltimer) != 0, "Failed to start timer\n");
-    ZF_LOGF_IF(ltimer_set_timeout(&env->ltimer, 100 * NS_IN_MS, TIMEOUT_PERIODIC) != 0, "Failed to configure timer\n");
+    ZF_LOGF_IF(ltimer_set_timeout(&env->ltimer, SAMPLE_TIME, TIMEOUT_PERIODIC) != 0, "Failed to configure timer\n");
 
     for (int i = 0; i < nr_cores; i++) {
         size_t name_sz = strlen("ping") + WORD_STRING_SIZE + 1;

--- a/apps/smp/src/main.c
+++ b/apps/smp/src/main.c
@@ -243,7 +243,7 @@ int main(int argc, char *argv[])
     }
 
     ZF_LOGF_IF(ltimer_reset(&env->ltimer) != 0, "Failed to start timer\n");
-    ZF_LOGF_IF(ltimer_set_timeout(&env->ltimer, NS_IN_S, TIMEOUT_PERIODIC) != 0, "Failed to configure timer\n");
+    ZF_LOGF_IF(ltimer_set_timeout(&env->ltimer, 100 * NS_IN_MS, TIMEOUT_PERIODIC) != 0, "Failed to configure timer\n");
 
     for (int i = 0; i < nr_cores; i++) {
         size_t name_sz = strlen("ping") + WORD_STRING_SIZE + 1;

--- a/libsel4benchsupport/include/smp.h
+++ b/libsel4benchsupport/include/smp.h
@@ -14,7 +14,7 @@
 #endif
 
 #define WARMUPS 2
-#define RUNS 5
+#define RUNS 10
 #define TESTS ARRAY_SIZE(smp_benchmark_params)
 
 typedef struct benchmark_params {


### PR DESCRIPTION
Since the SMP tests still have by far the longest running time:

Reduce the sample window from 1s to 100ms. This still should give us a pretty large number of IPCs even for the highest delay count.

To detect if there was noise, increase the number of total runs instead, so there is more data to work with.

Overall this should speed up the test by roughly a factor of 5.

Previous numbers will not be directly comparable, but they should be easy to convert (divide by 10 to get current setting). Not that we have looked at these numbers in years, but if we want to do automated performance regression checks, we should probably do this now rather than later.