### PR TITLE
add benchmark suite iterations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,72 +15,33 @@ find_package(elfloader-tool REQUIRED)
 
 # Configuration that applies to all apps
 if(NOT Sel4benchAllowSettingsOverride)
-    if(KernelArchARM)
-        if(KernelPlatformOMAP3 OR KernelPlatformAM335X)
-            set(KernelDangerousCodeInjection
-                ON
-                CACHE BOOL "" FORCE
-            )
-        else()
-            set(KernelArmExportPMUUser
-                ON
-                CACHE BOOL "" FORCE
-            )
-        endif()
+  if(KernelArchARM)
+    if(KernelPlatformOMAP3 OR KernelPlatformAM335X)
+      set(KernelDangerousCodeInjection ON CACHE BOOL "" FORCE)
     else()
-        set(KernelArmExportPMUUser
-            OFF
-            CACHE BOOL "" FORCE
-        )
+      set(KernelArmExportPMUUser ON CACHE BOOL "" FORCE)
     endif()
-    if(KernelArchX86)
-        set(KernelExportPMCUser
-            ON
-            CACHE BOOL "" FORCE
-        )
-        set(KernelX86DangerousMSR
-            ON
-            CACHE BOOL "" FORCE
-        )
-        set(AllowUnstableOverhead
-            ON
-            CACHE BOOL "" FORCE
-        )
-        set(KernelX86MicroArch
-            "haswell"
-            CACHE STRING "" FORCE
-        )
-        set(KernelXSaveFeatureSet
-            7
-            CACHE STRING "" FORCE
-        )
-        set(KernelXSaveSize
-            832
-            CACHE STRING "" FORCE
-        )
-    endif()
-    set(KernelRootCNodeSizeBits
-        15
-        CACHE STRING "" FORCE
-    )
-    set(KernelTimeSlice
-        500
-        CACHE STRING "" FORCE
-    )
-    set(KernelTimerTickMS
-        1000
-        CACHE STRING "" FORCE
-    )
-    set(KernelVerificationBuild
-        OFF
-        CACHE BOOL "" FORCE
-    )
+  else()
+    set(KernelArmExportPMUUser OFF CACHE BOOL "" FORCE)
+  endif()
+  if(KernelArchX86)
+    set(KernelExportPMCUser ON CACHE BOOL "" FORCE)
+    set(KernelX86DangerousMSR ON CACHE BOOL "" FORCE)
+    set(AllowUnstableOverhead ON CACHE BOOL "" FORCE)
+    set(KernelX86MicroArch "haswell" CACHE STRING "" FORCE)
+    set(KernelXSaveFeatureSet 7 CACHE STRING "" FORCE)
+    set(KernelXSaveSize 832 CACHE STRING "" FORCE)
+  endif()
+  set(KernelRootCNodeSizeBits 15 CACHE STRING "" FORCE)
+  set(KernelTimeSlice 500 CACHE STRING "" FORCE)
+  set(KernelTimerTickMS 1000 CACHE STRING "" FORCE)
+  set(KernelVerificationBuild OFF CACHE BOOL "" FORCE)
 endif()
 sel4_import_kernel()
 
 if((NOT Sel4benchAllowSettingsOverride) AND (KernelArchARM OR KernelArchRiscV))
-    # Elfloader settings that correspond to how Data61 sets its boards up.
-    ApplyData61ElfLoaderSettings(${KernelPlatform} ${KernelSel4Arch})
+  # Elfloader settings that correspond to how Data61 sets its boards up.
+  ApplyData61ElfLoaderSettings(${KernelPlatform} ${KernelSel4Arch})
 endif()
 elfloader_import_project()
 
@@ -88,11 +49,11 @@ elfloader_import_project()
 # If the program faults on a SIMD instruction for your platform,
 # update this code or find another work-around.
 function(general_regs_only target)
-    include(CheckCCompilerFlag OPTIONAL)
-    check_c_compiler_flag(-mgeneral-regs-only HAS_GENERAL_REGS_ONLY)
-    if(HAS_GENERAL_REGS_ONLY)
-        target_compile_options(${target} PRIVATE -mgeneral-regs-only)
-    endif()
+  include(CheckCCompilerFlag OPTIONAL)
+  check_c_compiler_flag(-mgeneral-regs-only HAS_GENERAL_REGS_ONLY)
+  if(HAS_GENERAL_REGS_ONLY)
+    target_compile_options(${target} PRIVATE -mgeneral-regs-only)
+  endif()
 endfunction()
 
 add_subdirectory(apps/sel4bench)
@@ -102,18 +63,12 @@ GenerateSimulateScript()
 
 # Platforms that don't have a timer can't use the benchmarks which need a timer.
 if(LibPlatSupportNoPlatformLtimer)
-    if(AppIrqUserBench)
-        message(WARNING "Platform has no timer, disabling IRQUSER bench")
-        set(AppIrqUserBench
-            OFF
-            CACHE BOOL "" FORCE
-        )
-    endif()
-    if(AppSmpBench)
-        message(WARNING "Platform has no timer, disabling SMP bench")
-        set(AppSmpBench
-            OFF
-            CACHE BOOL "" FORCE
-        )
-    endif()
+  if(AppIrqUserBench)
+    message(WARNING "Platform has no timer, disabling IRQUSER bench")
+    set(AppIrqUserBench OFF CACHE BOOL "" FORCE)
+  endif()
+  if(AppSmpBench)
+    message(WARNING "Platform has no timer, disabling SMP bench")
+    set(AppSmpBench OFF CACHE BOOL "" FORCE)
+  endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,7 @@ if(NOT Sel4benchAllowSettingsOverride)
         )
     endif()
     set(KernelRootCNodeSizeBits
-        13
+        15
         CACHE STRING "" FORCE
     )
     set(KernelTimeSlice

--- a/apps/sel4bench/CMakeLists.txt
+++ b/apps/sel4bench/CMakeLists.txt
@@ -26,6 +26,14 @@ config_string(
     0
     UNQUOTE
 )
+config_string(
+    ITERATIONS
+    ITERATIONS
+    "Number of times each benchmark runs consecutively. Useful for collecting between-run noise data."
+    DEFAULT
+    1
+    UNQUOTE
+)
 
 # Default dependencies on kernel benchmarking features. Declared here so that
 # all the benchmark applications can use it

--- a/apps/sel4bench/CMakeLists.txt
+++ b/apps/sel4bench/CMakeLists.txt
@@ -10,7 +10,7 @@ project(sel4benchapp C)
 set(configure_string "")
 
 config_option(
-    AllowUnstableOverhead ALLOW_UNSTABLE_OVERHEAD "Do not fail when stable values are not stable."
+    AllowUnstableOverhead ALLOW_UNSTABLE_OVERHEAD "Do not fail when overhead values are not stable."
     DEFAULT OFF
 )
 config_option(

--- a/apps/sel4bench/CMakeLists.txt
+++ b/apps/sel4bench/CMakeLists.txt
@@ -9,43 +9,31 @@ cmake_minimum_required(VERSION 3.16.0)
 project(sel4benchapp C)
 set(configure_string "")
 
-config_option(
-    AllowUnstableOverhead ALLOW_UNSTABLE_OVERHEAD "Do not fail when overhead values are not stable."
-    DEFAULT OFF
-)
-config_option(
-    OutputRawResults OUTPUT_RAW_RESULTS
-    "As well as outputting statistics, dump raw results in JSON format." DEFAULT ON
-)
+config_option(AllowUnstableOverhead ALLOW_UNSTABLE_OVERHEAD
+              "Do not fail when overhead values are not stable." DEFAULT OFF)
+config_option(OutputRawResults OUTPUT_RAW_RESULTS
+              "As well as outputting statistics, dump raw results in JSON format." DEFAULT ON)
 config_string(
-    JsonIndent
-    JSON_INDENT
-    "Set the indent for JSON. By default it is 0, which is very fast to output, however setting\
+  JsonIndent
+  JSON_INDENT
+  "Set the indent for JSON. By default it is 0, which is very fast to output, however setting\
     the indent higher allows for more human readable output. Ranges from 0 to 31."
-    DEFAULT
-    0
-    UNQUOTE
-)
+  DEFAULT
+  0
+  UNQUOTE)
 config_string(
-    ITERATIONS
-    ITERATIONS
-    "Number of times each benchmark runs consecutively. Useful for collecting between-run noise data."
-    DEFAULT
-    1
-    UNQUOTE
-)
+  ITERATIONS ITERATIONS
+  "Number of times each benchmark runs consecutively. Useful for collecting between-run noise data."
+  DEFAULT 1 UNQUOTE)
 
 # Default dependencies on kernel benchmarking features. Declared here so that
 # all the benchmark applications can use it
-if((KernelArchX86
-    AND KernelExportPMCUser
-    AND KernelX86DangerousMSR)
-   OR (KernelArchARM AND KernelArmExportPMUUser)
-   OR (KernelArchArmCortexA8 AND KernelDangerousCodeInjection)
-)
-    set(DefaultBenchDeps TRUE)
+if((KernelArchX86 AND KernelExportPMCUser AND KernelX86DangerousMSR) OR (KernelArchARM
+                                                                         AND KernelArmExportPMUUser)
+   OR (KernelArchArmCortexA8 AND KernelDangerousCodeInjection))
+  set(DefaultBenchDeps TRUE)
 else()
-    set(DefaultBenchDeps FALSE)
+  set(DefaultBenchDeps FALSE)
 endif()
 
 find_package(musllibc REQUIRED)
@@ -59,16 +47,10 @@ find_package(projects_libs REQUIRED)
 musllibc_setup_build_environment_with_sel4runtime()
 sel4_import_libsel4()
 util_libs_import_libraries()
-set(LibSel4MuslcSysMorecoreBytes
-    0
-    CACHE STRING "" FORCE
-)
+set(LibSel4MuslcSysMorecoreBytes 0 CACHE STRING "" FORCE)
 sel4_libs_import_libraries()
 projects_libs_import_libraries()
-set(LibNanopb
-    ON
-    CACHE BOOL "" FORCE
-)
+set(LibNanopb ON CACHE BOOL "" FORCE)
 sel4_projects_libs_import_libraries()
 
 add_subdirectory(../fault fault)
@@ -88,36 +70,36 @@ add_subdirectory(../../libsel4benchsupport libsel4benchsupport)
 config_option(Sel4Bench SEL4_BENCH "Enable seL4 benchmarking" DEFAULT ON)
 
 if(Sel4Bench)
-    add_config_library(sel4benchapp "${configure_string}")
+  add_config_library(sel4benchapp "${configure_string}")
 
-    file(GLOB static src/*.c src/plat/${KernelPlatform}/*.c)
+  file(GLOB static src/*.c src/plat/${KernelPlatform}/*.c)
 
-    get_property(sel4benchapps GLOBAL PROPERTY sel4benchapps_property)
-    include(cpio)
-    makecpio(archive.o "${sel4benchapps}")
-    add_executable(sel4benchapp EXCLUDE_FROM_ALL ${static} archive.o)
+  get_property(sel4benchapps GLOBAL PROPERTY sel4benchapps_property)
+  include(cpio)
+  makecpio(archive.o "${sel4benchapps}")
+  add_executable(sel4benchapp EXCLUDE_FROM_ALL ${static} archive.o)
 
-    target_link_libraries(
-        sel4benchapp
-        jansson
-        sel4benchsupport
-        sel4
-        sel4muslcsys
-        sel4rpc
-        sel4_autoconf
-        sel4benchapp_Config
-        sel4benchfault_Config
-        hardware_Config
-        sel4benchipc_Config
-        sel4benchirquser_Config
-        sel4benchpagemapping_Config
-        sel4benchscheduler_Config
-        sel4benchsignal_Config
-        smp_Config
-        sel4benchsync_Config
-        sel4benchvcpu_Config
-        # Add new benchmark configs here
-    )
-    include(rootserver)
-    declarerootserver(sel4benchapp)
+  target_link_libraries(
+    sel4benchapp
+    jansson
+    sel4benchsupport
+    sel4
+    sel4muslcsys
+    sel4rpc
+    sel4_autoconf
+    sel4benchapp_Config
+    sel4benchfault_Config
+    hardware_Config
+    sel4benchipc_Config
+    sel4benchirquser_Config
+    sel4benchpagemapping_Config
+    sel4benchscheduler_Config
+    sel4benchsignal_Config
+    smp_Config
+    sel4benchsync_Config
+    sel4benchvcpu_Config
+    # Add new benchmark configs here
+  )
+  include(rootserver)
+  declarerootserver(sel4benchapp)
 endif()

--- a/apps/sel4bench/src/main.c
+++ b/apps/sel4bench/src/main.c
@@ -256,6 +256,18 @@ void find_untyped(vka_t *vka, vka_object_t *untyped)
     ZF_LOGF_IF(error, "Failed to find free untyped\n");
 }
 
+/* add iteration run number to each entry in the json result array */
+static void add_iteration_tag(json_t *result, int run)
+{
+    size_t idx;
+    json_t *result_set;
+    json_array_foreach(result, idx, result_set) {
+        /* result_set points to entry at index idx in json array */
+        int error = json_object_set_new(result_set, "Iteration", json_integer(run));
+        ZF_LOGF_IF(error != 0, "Failed to set iteration number");
+    }
+}
+
 void *main_continued(void *arg)
 {
 
@@ -286,13 +298,16 @@ void *main_continued(void *arg)
     assert(output != NULL);
     int error;
 
-    /* run the benchmarks */
+    /* run the benchmarks, each with ITERATIONS consecutive runs */
     for (int i = 0; benchmarks[i] != NULL; i++) {
         if (benchmarks[i]->enabled) {
-            json_t *result = launch_benchmark(benchmarks[i], &global_env);
-            ZF_LOGF_IF(result == NULL, "Failed to run benchmark %s", benchmarks[i]->name);
-            error = json_array_extend(output, result);
-            ZF_LOGF_IF(error != 0, "Failed to add benchmark results");
+            for (int run = 0; run < CONFIG_ITERATIONS; run++) {
+                json_t *result = launch_benchmark(benchmarks[i], &global_env);
+                ZF_LOGF_IF(result == NULL, "Failed to run benchmark %s", benchmarks[i]->name);
+                add_iteration_tag(result, run);
+                error = json_array_extend(output, result);
+                ZF_LOGF_IF(error != 0, "Failed to add benchmark results");
+            }
         }
     }
 

--- a/apps/sel4bench/src/main.c
+++ b/apps/sel4bench/src/main.c
@@ -217,7 +217,11 @@ int run_benchmark(env_t *env, benchmark_t *benchmark, void *local_results_vaddr,
 
 json_t *launch_benchmark(benchmark_t *benchmark, env_t *env, int run)
 {
-    printf("\n%s Benchmarks (iteration %d)\n==============\n\n", benchmark->name, run);
+    int title_len = printf("\n%s Benchmarks (iteration %d)\n", benchmark->name, run) - 2;
+    for (int i = 0; i < title_len; i++) {
+        putchar('=');
+    }
+    printf("\n\n");
 
     /* reserve memory for the results */
     void *results = vspace_new_pages(&env->vspace, seL4_AllRights, benchmark->results_pages, seL4_PageBits);

--- a/apps/sel4bench/src/main.c
+++ b/apps/sel4bench/src/main.c
@@ -215,9 +215,9 @@ int run_benchmark(env_t *env, benchmark_t *benchmark, void *local_results_vaddr,
     return result;
 }
 
-json_t *launch_benchmark(benchmark_t *benchmark, env_t *env)
+json_t *launch_benchmark(benchmark_t *benchmark, env_t *env, int run)
 {
-    printf("\n%s Benchmarks\n==============\n\n", benchmark->name);
+    printf("\n%s Benchmarks (iteration %d)\n==============\n\n", benchmark->name, run);
 
     /* reserve memory for the results */
     void *results = vspace_new_pages(&env->vspace, seL4_AllRights, benchmark->results_pages, seL4_PageBits);
@@ -302,7 +302,7 @@ void *main_continued(void *arg)
     for (int i = 0; benchmarks[i] != NULL; i++) {
         if (benchmarks[i]->enabled) {
             for (int run = 0; run < CONFIG_ITERATIONS; run++) {
-                json_t *result = launch_benchmark(benchmarks[i], &global_env);
+                json_t *result = launch_benchmark(benchmarks[i], &global_env, run);
                 ZF_LOGF_IF(result == NULL, "Failed to run benchmark %s", benchmarks[i]->name);
                 add_iteration_tag(result, run);
                 error = json_array_extend(output, result);

--- a/easy-settings.cmake
+++ b/easy-settings.cmake
@@ -17,89 +17,44 @@
 #
 # ../griddle --PLATFORM=sabre --SIMULATION ninja
 #
-set(RELEASE
-    ON
-    CACHE BOOL "Performance optimized build"
-)
-set(PLATFORM
-    "x86_64"
-    CACHE STRING "Platform to test"
-)
-set(FASTPATH
-    ON
-    CACHE BOOL "Turn fastpath on or off"
-)
-set(ARM_HYP
-    OFF
-    CACHE BOOL "ARM EL2 hypervisor features on or off"
-)
-set(MCS
-    OFF
-    CACHE BOOL "MCS kernel"
-)
+set(RELEASE ON CACHE BOOL "Performance optimized build")
+set(PLATFORM "x86_64" CACHE STRING "Platform to test")
+set(FASTPATH ON CACHE BOOL "Turn fastpath on or off")
+set(ARM_HYP OFF CACHE BOOL "ARM EL2 hypervisor features on or off")
+set(MCS OFF CACHE BOOL "MCS kernel")
 
 # Set the list of benchmark applications to be included into the image Add any
 # new benchmark applications to this list
 
 # default is OFF
-set(HARDWARE
-    OFF
-    CACHE BOOL "Application to benchmark hardware-related operations"
-)
+set(HARDWARE OFF CACHE BOOL "Application to benchmark hardware-related operations")
 
 # default is OFF
-set(FAULT
-    OFF
-    CACHE BOOL "Application to benchmark seL4 faults"
-)
+set(FAULT OFF CACHE BOOL "Application to benchmark seL4 faults")
 
 # default is OFF
-set(VCPU
-    OFF
-    CACHE BOOL "Application to benchmark seL4 VCPU performance"
-)
+set(VCPU OFF CACHE BOOL "Application to benchmark seL4 VCPU performance")
 
 # default is OFF
-set(SMP
-    OFF
-    CACHE BOOL "Application SMP benchmarks"
-)
+set(SMP OFF CACHE BOOL "Application SMP benchmarks")
 
 # default is ON
-set(IPC
-    ON
-    CACHE BOOL "Application to benchmark seL4 IPC"
-)
+set(IPC ON CACHE BOOL "Application to benchmark seL4 IPC")
 
 # default is ON
-set(IRQUSER
-    ON
-    CACHE BOOL "Application to benchmark seL4 IRQs"
-)
+set(IRQUSER ON CACHE BOOL "Application to benchmark seL4 IRQs")
 
 # default is ON
-set(SCHED
-    ON
-    CACHE BOOL "Application to benchmark seL4 scheduler"
-)
+set(SCHED ON CACHE BOOL "Application to benchmark seL4 scheduler")
 
 # default is ON
-set(SIGNAL
-    ON
-    CACHE BOOL "Application to benchmark seL4 signals"
-)
+set(SIGNAL ON CACHE BOOL "Application to benchmark seL4 signals")
 
 # default is ON
-set(MAPPING
-    ON
-    CACHE BOOL "Application to benchmark seL4 mapping a series of pages"
-)
+set(MAPPING ON CACHE BOOL "Application to benchmark seL4 mapping a series of pages")
 
 # default is ON
-set(SYNC
-    ON
-    CACHE BOOL "Application to benchmark seL4 sync"
-)
+set(SYNC ON CACHE BOOL "Application to benchmark seL4 sync")
 
 # Allow Early Processing methodology for Signal/"Signal to High Prio Thread"
 # benchmark set(AppSignalEarlyProcessing ON)

--- a/settings.cmake
+++ b/settings.cmake
@@ -9,17 +9,10 @@ cmake_minimum_required(VERSION 3.16.0)
 set(project_dir "${CMAKE_CURRENT_LIST_DIR}/../..")
 file(GLOB project_modules ${project_dir}/projects/*)
 list(APPEND CMAKE_MODULE_PATH ${project_dir}/kernel ${project_dir}/tools/seL4/cmake-tool/helpers/
-     ${project_dir}/tools/seL4/elfloader-tool/ ${project_modules}
-)
+     ${project_dir}/tools/seL4/elfloader-tool/ ${project_modules})
 
-set(NANOPB_SRC_ROOT_FOLDER
-    "${project_dir}/nanopb"
-    CACHE STRING "NanoPB Folder location"
-)
-set(OPENSBI_PATH
-    "${project_dir}/tools/opensbi"
-    CACHE STRING "OpenSBI Folder location"
-)
+set(NANOPB_SRC_ROOT_FOLDER "${project_dir}/nanopb" CACHE STRING "NanoPB Folder location")
+set(OPENSBI_PATH "${project_dir}/tools/opensbi" CACHE STRING "OpenSBI Folder location")
 
 set(SEL4_CONFIG_DEFAULT_ADVANCED ON)
 include(application_settings)
@@ -27,10 +20,7 @@ include(application_settings)
 include(${CMAKE_CURRENT_LIST_DIR}/easy-settings.cmake)
 
 if(VCPU)
-    set(ARM_HYP
-        ON
-        CACHE BOOL "ARM EL2 hypervisor features on or off" FORCE
-    )
+  set(ARM_HYP ON CACHE BOOL "ARM EL2 hypervisor features on or off" FORCE)
 endif()
 correct_platform_strings()
 
@@ -40,251 +30,136 @@ sel4_configure_platform_settings()
 set(valid_platforms ${KernelPlatform_all_strings} ${correct_platform_strings_platform_aliases})
 set_property(CACHE PLATFORM PROPERTY STRINGS ${valid_platforms})
 if(NOT "${PLATFORM}" IN_LIST valid_platforms)
-    message(FATAL_ERROR "Invalid PLATFORM selected: \"${PLATFORM}\"
-Valid platforms are: \"${valid_platforms}\""
-    )
+  message(FATAL_ERROR "Invalid PLATFORM selected: \"${PLATFORM}\"
+Valid platforms are: \"${valid_platforms}\"")
 endif()
 
 # Declare a cache variable that enables/disablings the forcing of cache
 # variables to the specific test values. By default it is disabled
-set(Sel4benchAllowSettingsOverride
-    OFF
-    CACHE BOOL "Allow user to override configuration settings"
-)
+set(Sel4benchAllowSettingsOverride OFF CACHE BOOL "Allow user to override configuration settings")
 if(NOT Sel4benchAllowSettingsOverride)
-    # We use 'FORCE' when settings these values instead of 'INTERNAL' so that they
-    # still appear in the cmake-gui to prevent excessively confusing users
-    # Determine the platform/architecture
-    if(KernelArchARM)
-        if(NOT VCPU)
-            set(AppVcpuBench
-                OFF
-                CACHE BOOL "" FORCE
-            )
-        endif()
-        if(KernelSel4ArchAarch64)
-            if(ARM_HYP)
-                set(KernelArmHypervisorSupport
-                    ON
-                    CACHE BOOL "" FORCE
-                )
-            endif()
-        endif()
-
-    endif()
-
-    if(KernelSel4ArchAarch32)
-        set(KernelArmTLSReg
-            tpidruro
-            CACHE STRING "" FORCE
-        )
+  # We use 'FORCE' when settings these values instead of 'INTERNAL' so that they
+  # still appear in the cmake-gui to prevent excessively confusing users
+  # Determine the platform/architecture
+  if(KernelArchARM)
+    if(NOT VCPU)
+      set(AppVcpuBench OFF CACHE BOOL "" FORCE)
     endif()
     if(KernelSel4ArchAarch64)
-        set(KernelArmTLSReg
-            tpidru
-            CACHE STRING "" FORCE
-        )
+      if(ARM_HYP)
+        set(KernelArmHypervisorSupport ON CACHE BOOL "" FORCE)
+      endif()
     endif()
 
-    # Setup flags for RELEASE (performance optimized builds)
-    applycommonreleaseverificationsettings(${RELEASE} OFF)
-    # This option is controlled by ApplyCommonReleaseVerificationSettings
-    mark_as_advanced(CMAKE_BUILD_TYPE)
+  endif()
+
+  if(KernelSel4ArchAarch32)
+    set(KernelArmTLSReg tpidruro CACHE STRING "" FORCE)
+  endif()
+  if(KernelSel4ArchAarch64)
+    set(KernelArmTLSReg tpidru CACHE STRING "" FORCE)
+  endif()
+
+  # Setup flags for RELEASE (performance optimized builds)
+  applycommonreleaseverificationsettings(${RELEASE} OFF)
+  # This option is controlled by ApplyCommonReleaseVerificationSettings
+  mark_as_advanced(CMAKE_BUILD_TYPE)
+  if(RELEASE)
+    if(NOT KernelArchRiscV)
+      set(KernelFWholeProgram ON CACHE BOOL "" FORCE)
+    endif()
+  endif()
+
+  if(FASTPATH)
+    set(KernelFastpath ON CACHE BOOL "" FORCE)
+  else()
+    set(KernelFastpath OFF CACHE BOOL "" FORCE)
+  endif()
+
+  # App-specific configuration
+  if(FAULT)
+    set(AppFaultBench ON CACHE BOOL "" FORCE)
+  else()
+    set(AppFaultBench OFF CACHE BOOL "" FORCE)
+  endif()
+
+  if(HARDWARE)
+    set(KernelBenchmarks "generic" CACHE STRING "" FORCE)
+    set(AppHardwareBench ON CACHE BOOL "" FORCE)
+  elseif(VCPU)
+    # The VCPU benchmarks require the kernel entry and exit timestamp feature.
+    set(AppVcpuBench ON CACHE BOOL "" FORCE)
+    set(KernelBenchmarks "track_kernel_entries" CACHE STRING "" FORCE)
+  else()
+    set(KernelBenchmarks "none" CACHE STRING "" FORCE)
+    set(AppHardwareBench OFF CACHE BOOL "" FORCE)
+  endif()
+
+  if(SMP)
     if(RELEASE)
-        if(NOT KernelArchRiscV)
-            set(KernelFWholeProgram
-                ON
-                CACHE BOOL "" FORCE
-            )
-        endif()
-    endif()
-
-    if(FASTPATH)
-        set(KernelFastpath
-            ON
-            CACHE BOOL "" FORCE
-        )
+      if(KernelPlatformIMX93)
+        set(KernelMaxNumNodes 2 CACHE STRING "" FORCE)
+      else()
+        set(KernelMaxNumNodes 4 CACHE STRING "" FORCE)
+      endif()
+      set(AppSmpBench ON CACHE BOOL "" FORCE)
+      if(KernelPlatImx6)
+        set(ElfloaderMode "secure supervisor" CACHE STRING "" FORCE)
+      elseif(KernelPlatformTK1)
+        set(ElfloaderMode "monitor" CACHE STRING "" FORCE)
+      endif()
     else()
-        set(KernelFastpath
-            OFF
-            CACHE BOOL "" FORCE
-        )
+      message(FATAL_ERROR "SMP requires release build (-DRELEASE=TRUE)")
     endif()
-
-    # App-specific configuration
-    if(FAULT)
-        set(AppFaultBench
-            ON
-            CACHE BOOL "" FORCE
-        )
-    else()
-        set(AppFaultBench
-            OFF
-            CACHE BOOL "" FORCE
-        )
+  else()
+    set(KernelMaxNumNodes 1 CACHE STRING "" FORCE)
+    set(AppSmpBench OFF CACHE BOOL "" FORCE)
+    if(KernelPlatformTK1)
+      set(ElfloaderMode "monitor" CACHE STRING "" FORCE)
     endif()
+  endif()
 
-    if(HARDWARE)
-        set(KernelBenchmarks
-            "generic"
-            CACHE STRING "" FORCE
-        )
-        set(AppHardwareBench
-            ON
-            CACHE BOOL "" FORCE
-        )
-    elseif(VCPU)
-        # The VCPU benchmarks require the kernel entry and exit timestamp feature.
-        set(AppVcpuBench
-            ON
-            CACHE BOOL "" FORCE
-        )
-        set(KernelBenchmarks
-            "track_kernel_entries"
-            CACHE STRING "" FORCE
-        )
-    else()
-        set(KernelBenchmarks
-            "none"
-            CACHE STRING "" FORCE
-        )
-        set(AppHardwareBench
-            OFF
-            CACHE BOOL "" FORCE
-        )
-    endif()
+  if(MCS)
+    set(KernelIsMCS ON CACHE BOOL "" FORCE)
+  else()
+    set(KernelIsMCS OFF CACHE BOOL "" FORCE)
+  endif()
 
-    if(SMP)
-        if(RELEASE)
-            if(KernelPlatformIMX93)
-                set(KernelMaxNumNodes
-                    2
-                    CACHE STRING "" FORCE
-                )
-            else()
-                set(KernelMaxNumNodes
-                    4
-                    CACHE STRING "" FORCE
-                )
-            endif()
-            set(AppSmpBench
-                ON
-                CACHE BOOL "" FORCE
-            )
-            if(KernelPlatImx6)
-                set(ElfloaderMode
-                    "secure supervisor"
-                    CACHE STRING "" FORCE
-                )
-            elseif(KernelPlatformTK1)
-                set(ElfloaderMode
-                    "monitor"
-                    CACHE STRING "" FORCE
-                )
-            endif()
-        else()
-            message(FATAL_ERROR "SMP requires release build (-DRELEASE=TRUE)")
-        endif()
-    else()
-        set(KernelMaxNumNodes
-            1
-            CACHE STRING "" FORCE
-        )
-        set(AppSmpBench
-            OFF
-            CACHE BOOL "" FORCE
-        )
-        if(KernelPlatformTK1)
-            set(ElfloaderMode
-                "monitor"
-                CACHE STRING "" FORCE
-            )
-        endif()
-    endif()
+  if(IPC)
+    set(AppIpcBench ON CACHE BOOL "" FORCE)
+  else()
+    set(AppIpcBench OFF CACHE BOOL "" FORCE)
+  endif()
 
-    if(MCS)
-        set(KernelIsMCS
-            ON
-            CACHE BOOL "" FORCE
-        )
-    else()
-        set(KernelIsMCS
-            OFF
-            CACHE BOOL "" FORCE
-        )
-    endif()
+  if(IRQUSER)
+    set(AppIrqUserBench ON CACHE BOOL "" FORCE)
+  else()
+    set(AppIrqUserBench OFF CACHE BOOL "" FORCE)
+  endif()
 
-    if(IPC)
-        set(AppIpcBench
-            ON
-            CACHE BOOL "" FORCE
-        )
-    else()
-        set(AppIpcBench
-            OFF
-            CACHE BOOL "" FORCE
-        )
-    endif()
+  if(SCHED)
+    set(AppSchedulerBench ON CACHE BOOL "" FORCE)
+  else()
+    set(AppSchedulerBench OFF CACHE BOOL "" FORCE)
+  endif()
 
-    if(IRQUSER)
-        set(AppIrqUserBench
-            ON
-            CACHE BOOL "" FORCE
-        )
-    else()
-        set(AppIrqUserBench
-            OFF
-            CACHE BOOL "" FORCE
-        )
-    endif()
+  if(SIGNAL)
+    set(AppSignalBench ON CACHE BOOL "" FORCE)
+  else()
+    set(AppSignalBench OFF CACHE BOOL "" FORCE)
+  endif()
 
-    if(SCHED)
-        set(AppSchedulerBench
-            ON
-            CACHE BOOL "" FORCE
-        )
-    else()
-        set(AppSchedulerBench
-            OFF
-            CACHE BOOL "" FORCE
-        )
-    endif()
+  if(MAPPING)
+    set(AppPageMappingBench ON CACHE BOOL "" FORCE)
+  else()
+    set(AppPageMappingBench OFF CACHE BOOL "" FORCE)
+  endif()
 
-    if(SIGNAL)
-        set(AppSignalBench
-            ON
-            CACHE BOOL "" FORCE
-        )
-    else()
-        set(AppSignalBench
-            OFF
-            CACHE BOOL "" FORCE
-        )
-    endif()
+  if(SYNC)
+    set(AppSyncBench ON CACHE BOOL "" FORCE)
+  else()
+    set(AppSyncBench OFF CACHE BOOL "" FORCE)
+  endif()
 
-    if(MAPPING)
-        set(AppPageMappingBench
-            ON
-            CACHE BOOL "" FORCE
-        )
-    else()
-        set(AppPageMappingBench
-            OFF
-            CACHE BOOL "" FORCE
-        )
-    endif()
-
-    if(SYNC)
-        set(AppSyncBench
-            ON
-            CACHE BOOL "" FORCE
-        )
-    else()
-        set(AppSyncBench
-            OFF
-            CACHE BOOL "" FORCE
-        )
-    endif()
-
-    # Add new app-specific configuration here
+  # Add new app-specific configuration here
 endif()


### PR DESCRIPTION
Add optional iteration count for consecutive benchmark repeats for collecting noise/variation between full runs regardless of in-run stddev.

This is the data that is needed to determine whether a benchmark result from a new run has a statistically significant difference to the previous runs. Within-run stddev is irrelevant for this, because we have benchmarks with high stddev and very stable mean, and benchmarks with stddev=0 that still have a varying mean between runs.

I tested repeating benchmarks consecutively vs repeating the whole suite vs rebooting the board and doing another full run for the IPC benchmarks on different boards. Noise between these 3 options was almost equal, with consecutive runs being the noisiest (by a very small margin, usually less than 1 cycle stddev difference to a reboot). Given that consecutive runs are the fastest to run and seem to be the best upper bound for noise, I chose that option.

To make this work, I had to increase the size of the root CNode, because json output allocation was running out of cnode slots (plenty of memory left, only cnode slots, because every page needs multiple slots and some benchmarks need a lot of free slots). AFAICT benchmark cleanup itself is working fine, the only leak seems to be the json output esp when there are large result arrays.

Additional cosmetic changes (separate commits):
- add iteration number to title print
- fix the title underline (has been bugging me forever)