### PR TITLE
github: add iterations argument for manual trigger

### DIFF
--- a/.github/workflows/sel4bench.yml
+++ b/.github/workflows/sel4bench.yml
@@ -14,6 +14,11 @@ on:
 
   # allow manual trigger
   workflow_dispatch:
+    inputs:
+      iterations:
+        description: 'Number of sel4bench iterations'
+        type: number
+        default: 5
 
   # allow explict trigger from other repos when dependencies have changed
   repository_dispatch:
@@ -46,6 +51,8 @@ jobs:
       with:
         xml: ${{ needs.code.outputs.xml }}
         march: ${{ matrix.march }}
+        # empty when not triggered by workflow_dispatch:
+        iterations: ${{ inputs.iterations }}
     - name: Upload images
       uses: actions/upload-artifact@v7
       with:


### PR DESCRIPTION
Allow specifying the number of iterations when manually triggering the deployment workflow via workflow_dispatch.

Results will be recorded and displayed on the web page like a normal deployment run.

Needs to be merged after https://github.com/seL4/ci-actions/pull/504