### PR TITLE
github: scale timeout for sel4bench-hw

### DIFF
--- a/.github/workflows/sel4bench.yml
+++ b/.github/workflows/sel4bench.yml
@@ -104,6 +104,8 @@ jobs:
           platform: ${{ matrix.platform }}
           req: ${{ matrix.req }}
           index: ${{ strategy.job-index }}
+          # empty when not triggered by workflow_dispatch:
+          iterations: ${{ inputs.iterations }}
         env:
           HW_SSH: ${{ secrets.HW_SSH }}
       - name: Upload results


### PR DESCRIPTION
Give the hardware run job the number of iterations so it can scale the job timeout accordingly.

Depends on https://github.com/seL4/ci-actions/pull/505